### PR TITLE
Update Docker images for ScyllaDB and MinIO

### DIFF
--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   scylladb:
-    image: scylladb/scylla:5.2.7
+    image: scylladb/scylla:2025.3
     container_name: tessaro-scylladb
     restart: always
     command: --experimental 1
@@ -21,7 +21,7 @@ services:
       retries: 5
 
   minio:
-    image: minio/minio:RELEASE.2023-05-18T00-05-36Z
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     container_name: tessaro-minio
     restart: always
     environment:
@@ -42,7 +42,7 @@ services:
       retries: 3
 
   create-buckets:
-    image: minio/mc:RELEASE.2023-05-18T00-05-36Z
+    image: minio/mc:RELEASE.2025-09-07T16-13-09Z
     container_name: tessaro-create-buckets
     depends_on:
       - minio


### PR DESCRIPTION
## Summary
- bump the ScyllaDB container to the 2025.3 release
- update MinIO and the mc client to the RELEASE.2025-09-07T16-13-09Z version

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7845bb4d08327a37f24950f8072ab