### PR TITLE
Add Flux reconciliation helper script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,10 @@
 # Repository Guidelines
 
-> ⚠️ **IMPORTANT**: This repository uses GitOps with FluxCD for all infrastructure and application management. 
-> **NEVER** run commands directly on the Kubernetes cluster. **ONLY** update the manifests in this repository 
-> and let FluxCD reconcile the changes. Once you've made changes, push to a new branch and create a PR.
+> ⚠️ **IMPORTANT**: This repository uses GitOps with FluxCD for all infrastructure and application management.
+> **NEVER** run commands directly on the Kubernetes cluster. **ONLY** update the manifests in this repository,
+> commit the change, and let FluxCD reconcile it. Use the `./scripts/reconcile-flux.sh` helper (or the equivalent
+> `flux reconcile kustomization ...` commands) to apply updates after modifying manifests. Once you've made
+> changes, push to a new branch and create a PR.
 
 ## Project Structure & Module Organization
 This monorepo separates UI shells, shared libraries, and platform tooling. Keep feature logic in reusable libs and keep app folders thin.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Tessaro Monorepo
 
-> ⚠️ **IMPORTANT**: This repository uses GitOps with FluxCD for all infrastructure and application management. 
-> **NEVER** run commands directly on the Kubernetes cluster. **ONLY** update the manifests in this repository 
-> and let FluxCD reconcile the changes. Once you've made changes, push to a new branch and create a PR.
+> ⚠️ **IMPORTANT**: This repository uses GitOps with FluxCD for all infrastructure and application management.
+> **NEVER** run commands directly on the Kubernetes cluster. **ONLY** update the manifests in this repository,
+> commit the change, and reconcile Flux to apply it. Once you've made changes, push to a new branch and create a PR.
 
 This repository contains all code and infrastructure for the **Tessaro platform**, including the **Admin Interface** and the **Main App** (customer-facing). It is organized as a monorepo to enable shared libraries, consistent CI/CD, and Infrastructure-as-Code management.
 
@@ -116,13 +116,13 @@ Tessaro is a SaaS platform providing multiple services under one umbrella. Custo
 
 ### Running Locally
 
-> ⚠️ **IMPORTANT**: This repository uses GitOps with FluxCD for all infrastructure and application management. 
-> **NEVER** run commands directly on the Kubernetes cluster. **ONLY** update the manifests in this repository 
-> and let FluxCD reconcile the changes. Once you've made changes, push to a new branch and create a PR.
+> ⚠️ **IMPORTANT**: This repository uses GitOps with FluxCD for all infrastructure and application management.
+> **NEVER** run commands directly on the Kubernetes cluster. **ONLY** update the manifests in this repository,
+> commit the change, and reconcile Flux to apply it. Once you've made changes, push to a new branch and create a PR.
 
 Knative now hosts the serverless APIs. Deployments flow through Flux, so local workflows typically involve:
 
-* Triggering a reconciliation (`flux reconcile kustomization home`) after changing manifests.
+* Triggering a reconciliation with `./scripts/reconcile-flux.sh` (or `flux reconcile kustomization home`) after changing manifests.
 * Using `kubectl port-forward svc/users-api-get -n apps 8080:80` (or `kn service proxy`) to exercise functions locally.
 
 For configuration management, the platform now uses Kubernetes ConfigMaps. When running locally, ensure that the `tessaro-config` ConfigMap is deployed to your cluster. This ConfigMap contains environment-specific configuration such as service URLs and CORS origins.
@@ -154,9 +154,22 @@ Then set `VITE_USERS_API_URL=http://localhost:8080` when starting the admin app.
 
 ## Deployment
 
-> ⚠️ **IMPORTANT**: This repository uses GitOps with FluxCD for all infrastructure and application management. 
-> **NEVER** run commands directly on the Kubernetes cluster. **ONLY** update the manifests in this repository 
-> and let FluxCD reconcile the changes. Once you've made changes, push to a new branch and create a PR.
+> ⚠️ **IMPORTANT**: This repository uses GitOps with FluxCD for all infrastructure and application management.
+> **NEVER** run commands directly on the Kubernetes cluster. **ONLY** update the manifests in this repository,
+> commit the change, and reconcile Flux to apply it. Once you've made changes, push to a new branch and create a PR.
+
+### Reconciliation workflow
+
+1. Update the desired manifests under `infra/k8s`.
+2. Commit the change to Git.
+3. Run the Flux reconciliation script to apply the desired state:
+
+   ```bash
+   ./scripts/reconcile-flux.sh
+   ```
+
+   Pass a custom kustomization name if required: `./scripts/reconcile-flux.sh tessaro-cluster`.
+4. Use the script output (or rerun `flux get kustomizations`) to confirm the reconciliation completed successfully.
 
 * CI/CD pipelines are defined in **.github/workflows/**.
 * Each push to `main` triggers build, test, and deploy steps.

--- a/scripts/reconcile-flux.sh
+++ b/scripts/reconcile-flux.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEFAULT_KUSTOMIZATION="home"
+FLUX_NAMESPACE="${FLUX_NAMESPACE:-flux-system}"
+KUSTOMIZATION_NAME="${1:-${DEFAULT_KUSTOMIZATION}}"
+
+usage() {
+  cat <<USAGE
+Usage: $0 [kustomization-name]
+
+Arguments:
+  kustomization-name  Optional Flux kustomization to reconcile (default: ${DEFAULT_KUSTOMIZATION})
+
+Environment:
+  FLUX_NAMESPACE      Namespace that hosts Flux resources (default: flux-system)
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if ! command -v flux >/dev/null 2>&1; then
+  echo "Error: flux CLI is required but was not found in PATH." >&2
+  exit 1
+fi
+
+reconcile_args=("kustomization" "${KUSTOMIZATION_NAME}" "--namespace" "${FLUX_NAMESPACE}" "--with-source")
+
+if [[ -n "${FLUX_TIMEOUT:-}" ]]; then
+  reconcile_args+=("--timeout" "${FLUX_TIMEOUT}")
+fi
+
+if [[ -n "${FLUX_OUTPUT:-}" ]]; then
+  reconcile_args+=("--output" "${FLUX_OUTPUT}")
+fi
+
+echo "Reconciling Flux kustomization '${KUSTOMIZATION_NAME}' in namespace '${FLUX_NAMESPACE}'..."
+flux reconcile "${reconcile_args[@]}"
+
+echo
+flux get kustomizations --namespace "${FLUX_NAMESPACE}"


### PR DESCRIPTION
## Summary
- add a helper script to trigger Flux reconciliation and display kustomization status
- document the GitOps reconciliation workflow in the README
- update the contributor guidance to use the reconciliation script instead of touching the cluster directly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddc356509c83278ad41bca9580ac45