### PR TITLE
fix(functions): provide cors type declarations fallback

### DIFF
--- a/apps/functions/shared/types/cors.d.ts
+++ b/apps/functions/shared/types/cors.d.ts
@@ -1,0 +1,25 @@
+import type { RequestHandler } from 'express';
+
+declare module 'cors' {
+  export type StaticOrigin = boolean | string | RegExp | Array<string | RegExp>;
+  export type DynamicOrigin = (
+    origin: string | undefined,
+    callback: (err: Error | null, allow?: StaticOrigin) => void
+  ) => void;
+
+  export interface CorsOptions {
+    origin?: StaticOrigin | DynamicOrigin;
+    methods?: string | string[];
+    allowedHeaders?: string | string[];
+    exposedHeaders?: string | string[];
+    credentials?: boolean;
+    maxAge?: number;
+    preflightContinue?: boolean;
+    optionsSuccessStatus?: number;
+  }
+
+  export type CorsRequestHandler = (options?: CorsOptions) => RequestHandler;
+
+  const cors: CorsRequestHandler;
+  export default cors;
+}


### PR DESCRIPTION
## Summary
- add a local ambient module declaration for `cors` so TypeScript can resolve the middleware when collecting coverage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ddc8bce61883278cdb241869b38406