### PR TITLE
Improve jest configuration and cover shared config utilities

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -5,10 +5,13 @@ module.exports = {
   testMatch: ['**/tests/**/*.test.ts?(x)'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.json'
-    }
+  transform: {
+    '^.+\\.[tj]sx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.json'
+      }
+    ]
   },
   moduleNameMapper: {
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',

--- a/shared/config/tests/app.test.ts
+++ b/shared/config/tests/app.test.ts
@@ -1,0 +1,68 @@
+import { createBaseApp, resolveCorsOptions, resolveHost, resolvePort } from '../app';
+
+describe('resolveCorsOptions', () => {
+  const originalEnv = process.env.CORS_ALLOWED_ORIGINS;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.CORS_ALLOWED_ORIGINS;
+    } else {
+      process.env.CORS_ALLOWED_ORIGINS = originalEnv;
+    }
+  });
+
+  it('allows all origins when the env var is missing', () => {
+    delete process.env.CORS_ALLOWED_ORIGINS;
+
+    expect(resolveCorsOptions()).toEqual({ origin: true });
+  });
+
+  it('returns a single origin when only one value is provided', () => {
+    process.env.CORS_ALLOWED_ORIGINS = 'https://example.com';
+
+    expect(resolveCorsOptions()).toEqual({ origin: 'https://example.com' });
+  });
+
+  it('returns a list of origins when multiple values are provided', () => {
+    process.env.CORS_ALLOWED_ORIGINS = 'https://a.com, https://b.com ,  https://c.com ';
+
+    expect(resolveCorsOptions()).toEqual({
+      origin: ['https://a.com', 'https://b.com', 'https://c.com']
+    });
+  });
+});
+
+describe('createBaseApp', () => {
+  it('registers the health endpoint', () => {
+    const app = createBaseApp();
+    const router = (app as any)._router;
+    const healthLayer = router.stack.find((layer: any) => layer.route?.path === '/health');
+
+    expect(healthLayer).toBeDefined();
+
+    const response = { json: jest.fn() } as any;
+    healthLayer.route.stack[0].handle({} as any, response, jest.fn());
+
+    expect(response.json).toHaveBeenCalledWith({ status: 'ok' });
+  });
+});
+
+describe('resolvePort', () => {
+  it('returns provided port when valid', () => {
+    expect(resolvePort('3000')).toBe(3000);
+  });
+
+  it('falls back to default when invalid', () => {
+    expect(resolvePort('invalid')).toBe(8080);
+  });
+});
+
+describe('resolveHost', () => {
+  it('returns provided host when valid', () => {
+    expect(resolveHost('127.0.0.1')).toBe('127.0.0.1');
+  });
+
+  it('falls back to default when invalid', () => {
+    expect(resolveHost('   ')).toBe('0.0.0.0');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,12 +10,11 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "jsx": "react-jsx",
-    "types": ["jest", "node", "@testing-library/jest-dom"],
+    "types": ["jest", "node", "@testing-library/jest-dom", "cors"],
     "baseUrl": ".",
     "paths": {
       "shared/libs/database": ["shared/libs/database/src"],
       "shared/libs/database/*": ["shared/libs/database/src/*"],
-      "shared/libs/*/*": ["shared/libs/*/src/*"],
       "shared/libs/*": ["shared/libs/*/src", "shared/libs/*"],
       "shared/config/*": ["shared/config/*"],
       "@/*": ["services/admin-app/app/src/*"]
@@ -29,5 +28,6 @@
     "shared/**/*.tsx",
     "shared/**/*.d.ts",
     "platform/**/*.ts"
-  ]
+  ],
+  "exclude": ["services/**/app/vite.config.ts"]
 }


### PR DESCRIPTION
## Summary
- move the ts-jest configuration into the transform section to silence the deprecation warning
- adjust the TypeScript project to load cors typings and ignore the Vite config that depends on local tooling
- add unit tests for the shared config app helpers, covering CORS, health route, port, and host utilities

## Testing
- npm test
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68ddd2c746308327a1a29b09b3e00e85