### PR TITLE
fix: restore cors typing compatibility

### DIFF
--- a/shared/config/app.ts
+++ b/shared/config/app.ts
@@ -1,5 +1,11 @@
 import express, { Express } from 'express';
-import cors, { CorsOptions } from 'cors';
+import cors from 'cors';
+
+type CorsOrigin = boolean | string | RegExp | Array<string | RegExp>;
+
+type CorsOptions = {
+  origin: CorsOrigin;
+};
 
 export const resolveCorsOptions = (): CorsOptions => {
   const rawOrigins = process.env.CORS_ALLOWED_ORIGINS;


### PR DESCRIPTION
## Summary
- update the shared app config to derive cors options without relying on named exports that ts-jest cannot resolve
- keep the existing cors normalization logic so coverage now includes the helper

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ddd4ed27048327969ba9b0739c0144