### PR TITLE
fix: honor CORS_ALLOWED_ORIGINS in config

### DIFF
--- a/shared/config/app.ts
+++ b/shared/config/app.ts
@@ -8,7 +8,26 @@ type CorsOptions = {
 };
 
 export const resolveCorsOptions = (): CorsOptions => {
-  return { origin: true };
+  const allowedOrigins = process.env.CORS_ALLOWED_ORIGINS;
+
+  if (allowedOrigins === undefined) {
+    return { origin: true };
+  }
+
+  const parsedOrigins = allowedOrigins
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter((origin) => origin.length > 0);
+
+  if (parsedOrigins.length === 0) {
+    return { origin: true };
+  }
+
+  if (parsedOrigins.length === 1) {
+    return { origin: parsedOrigins[0] };
+  }
+
+  return { origin: parsedOrigins };
 };
 
 export const createBaseApp = (): Express => {


### PR DESCRIPTION
## Summary
- parse the `CORS_ALLOWED_ORIGINS` environment variable to configure CORS
- keep default open access when the variable is unset or empty

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68ddd84d1330832786124d5900f2c1f0