### PR TITLE
test: relax coverage enforcement for selective runs

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,3 +1,18 @@
+const selectiveRunFlags = new Set([
+  '--runTestsByPath',
+  '--findRelatedTests'
+]);
+
+const isSelectiveRun = process.argv.some(arg => {
+  if (selectiveRunFlags.has(arg)) {
+    return true;
+  }
+
+  return selectiveRunFlags.has(arg.split('=')[0]);
+});
+
+const shouldCollectCoverage = !isSelectiveRun;
+
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
@@ -23,7 +38,7 @@ module.exports = {
     '^shared/libs/([^/]+)$': '<rootDir>/shared/libs/$1/src',
     '^shared/config/(.*)$': '<rootDir>/shared/config/$1'
   },
-  collectCoverage: true,
+  collectCoverage: shouldCollectCoverage,
   collectCoverageFrom: [
     '<rootDir>/services/**/*.ts',
     '<rootDir>/services/**/*.tsx',
@@ -36,13 +51,15 @@ module.exports = {
     '!<rootDir>/services/**/app/vite.config.ts',
     '!<rootDir>/shared/libs/api-client/**/*.ts'
   ],
-  coverageThreshold: {
-    global: {
-      branches: 35,
-      functions: 35,
-      lines: 35,
-      statements: 35
+  coverageThreshold: shouldCollectCoverage
+    ? {
+      global: {
+        branches: 35,
+        functions: 35,
+        lines: 35,
+        statements: 35
+      }
     }
-  },
+    : undefined,
   reporters: ['<rootDir>/shared/testing/colorized-reporter.js']
 };


### PR DESCRIPTION
## Summary
- skip coverage collection and threshold enforcement when Jest runs a focused subset of tests
- continue collecting coverage for full-suite runs so CI coverage requirements remain intact

## Testing
- npm test
- npx jest --runTestsByPath shared/config/tests/app.test.ts --reporters=default

------
https://chatgpt.com/codex/tasks/task_e_68dddb2822ac8327bef540f5d680ee2a