### PR TITLE
feat: expose kubernetes dashboard via traefik

### DIFF
--- a/platform/flux/platform/coredns/coredns-configmap.yaml
+++ b/platform/flux/platform/coredns/coredns-configmap.yaml
@@ -21,6 +21,7 @@ data:
         hosts {
            192.168.1.21 tessaro.dino.home
            192.168.1.21 admin.tessaro.dino.home
+           192.168.1.21 kubernetes.tessaro.dino.home
            fallthrough
         }
         prometheus :9153

--- a/platform/flux/platform/kubernetes-dashboard/kubernetes-dashboard-ingressroute.yaml
+++ b/platform/flux/platform/kubernetes-dashboard/kubernetes-dashboard-ingressroute.yaml
@@ -1,0 +1,15 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: kubernetes-dashboard
+  namespace: kubernetes-dashboard
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: HostSNI(`kubernetes.tessaro.dino.home`)
+      services:
+        - name: kubernetes-dashboard
+          port: 443
+  tls:
+    passthrough: true

--- a/platform/flux/platform/kubernetes-dashboard/kustomization.yaml
+++ b/platform/flux/platform/kubernetes-dashboard/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kubernetes-dashboard-ingressroute.yaml

--- a/platform/flux/platform/kustomization.yaml
+++ b/platform/flux/platform/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - coredns
+  - kubernetes-dashboard
   - knative
   - scylla-operator
   - tessaro-config.yaml


### PR DESCRIPTION
## Summary
- add a CoreDNS host record for kubernetes.tessaro.dino.home
- expose the Kubernetes dashboard through Traefik using a TCP IngressRoute
- wire the new dashboard manifest into the shared platform kustomization

## Testing
- not run (infrastructure manifest changes)


------
https://chatgpt.com/codex/tasks/task_e_68dde22788248327ab98932b342c2cfe