### PR TITLE
fix: stabilize organization management hook

### DIFF
--- a/services/admin-app/app/src/hooks/useOrganizationManagement.ts
+++ b/services/admin-app/app/src/hooks/useOrganizationManagement.ts
@@ -2,6 +2,17 @@ import React, { useState, useCallback } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import useApi from './useApi';
 
+const isTestEnvironment = typeof process !== 'undefined' && process.env?.NODE_ENV === 'test';
+const SIMULATED_NETWORK_DELAY_MS = isTestEnvironment ? 0 : 300;
+
+const simulateNetworkDelay = async () => {
+  if (SIMULATED_NETWORK_DELAY_MS <= 0) {
+    return;
+  }
+
+  await new Promise(resolve => setTimeout(resolve, SIMULATED_NETWORK_DELAY_MS));
+};
+
 interface Organization {
   id: string;
   name: string;
@@ -24,16 +35,14 @@ const useOrganizationManagement = () => {
     ];
     
     await executeRequest(async () => {
-      // Simulate API delay
-      await new Promise(resolve => setTimeout(resolve, 500));
+      await simulateNetworkDelay();
       setOrganizations(mockOrganizations);
     });
   }, [executeRequest]);
 
   const createOrganization = useCallback(async (orgData: Omit<Organization, 'id'>) => {
     return executeRequest(async () => {
-      // Simulate API call
-      await new Promise(resolve => setTimeout(resolve, 500));
+      await simulateNetworkDelay();
       const newOrg = { id: uuidv4(), ...orgData };
       setOrganizations(prev => [...prev, newOrg]);
       return newOrg;
@@ -42,8 +51,7 @@ const useOrganizationManagement = () => {
 
   const updateOrganization = useCallback(async (id: string, orgData: Partial<Organization>) => {
     return executeRequest(async () => {
-      // Simulate API call
-      await new Promise(resolve => setTimeout(resolve, 500));
+      await simulateNetworkDelay();
       setOrganizations(prev => prev.map(org => org.id === id ? { ...org, ...orgData } : org));
       setCurrentOrganization(prev => prev?.id === id ? { ...prev, ...orgData } : prev);
       return { id, ...orgData };
@@ -52,8 +60,7 @@ const useOrganizationManagement = () => {
 
   const deleteOrganization = useCallback(async (id: string) => {
     return executeRequest(async () => {
-      // Simulate API call
-      await new Promise(resolve => setTimeout(resolve, 500));
+      await simulateNetworkDelay();
       setOrganizations(prev => prev.filter(org => org.id !== id));
       if (currentOrganization?.id === id) {
         setCurrentOrganization(null);

--- a/services/admin-app/app/tests/useOrganizationManagement.hook.test.tsx
+++ b/services/admin-app/app/tests/useOrganizationManagement.hook.test.tsx
@@ -1,0 +1,69 @@
+import { act, renderHook } from '@testing-library/react';
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'org-123')
+}));
+
+describe('useOrganizationManagement hook', () => {
+  it('manages lifecycle actions for organizations', async () => {
+    const { default: useOrganizationManagement } = await import('../src/hooks/useOrganizationManagement');
+    const { result } = renderHook(() => useOrganizationManagement());
+
+    expect(result.current.organizations).toHaveLength(0);
+    expect(result.current.currentOrganization).toBeNull();
+
+    await act(async () => {
+      await result.current.fetchOrganizations();
+    });
+
+    expect(result.current.organizations).toHaveLength(3);
+    expect(result.current.loading).toBe(false);
+
+    await act(async () => {
+      await result.current.createOrganization({
+        name: 'New Org',
+        plan: 'Starter',
+        status: 'Active'
+      });
+    });
+
+    expect(result.current.organizations).toHaveLength(4);
+    expect(result.current.organizations.find(org => org.id === 'org-123')).toMatchObject({
+      name: 'New Org',
+      plan: 'Starter',
+      status: 'Active'
+    });
+
+    act(() => {
+      const created = result.current.organizations.find(org => org.id === 'org-123');
+      if (!created) {
+        throw new Error('expected organization to exist');
+      }
+      result.current.selectOrganization(created);
+    });
+
+    expect(result.current.currentOrganization?.id).toBe('org-123');
+
+    await act(async () => {
+      await result.current.updateOrganization('org-123', { status: 'Suspended' });
+    });
+
+    expect(result.current.organizations.find(org => org.id === 'org-123')?.status).toBe('Suspended');
+    expect(result.current.currentOrganization?.status).toBe('Suspended');
+
+    await act(async () => {
+      await result.current.deleteOrganization('org-123');
+    });
+
+    expect(result.current.organizations.find(org => org.id === 'org-123')).toBeUndefined();
+    expect(result.current.currentOrganization).toBeNull();
+
+    act(() => {
+      result.current.deselectOrganization();
+      result.current.clearError();
+    });
+
+    expect(result.current.currentOrganization).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- reduce the simulated network delay in `useOrganizationManagement` so the hook no longer slows down the Jest suite in test environments
- add a dedicated hook test that exercises organization lifecycle actions to guard the new behavior

## Testing
- npm test -- --runInBand


------
https://chatgpt.com/codex/tasks/task_e_68ddeb959530832785ffc77f6f005a63