### PR TITLE
fix: redirect kubernetes dashboard http traffic

### DIFF
--- a/platform/flux/platform/kubernetes-dashboard/kubernetes-dashboard-redirect.yaml
+++ b/platform/flux/platform/kubernetes-dashboard/kubernetes-dashboard-redirect.yaml
@@ -1,0 +1,26 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: kubernetes-dashboard-https-redirect
+  namespace: kubernetes-dashboard
+spec:
+  redirectScheme:
+    scheme: https
+    port: "443"
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: kubernetes-dashboard-web
+  namespace: kubernetes-dashboard
+spec:
+  entryPoints:
+    - web
+  routes:
+    - kind: Rule
+      match: Host(`kubernetes.tessaro.dino.home`)
+      middlewares:
+        - name: kubernetes-dashboard-https-redirect
+      services:
+        - kind: TraefikService
+          name: noop@internal

--- a/platform/flux/platform/kubernetes-dashboard/kustomization.yaml
+++ b/platform/flux/platform/kubernetes-dashboard/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - kubernetes-dashboard-ingressroute.yaml
+  - kubernetes-dashboard-redirect.yaml


### PR DESCRIPTION
## Summary
- add Traefik middleware and ingress route to redirect HTTP requests for the Kubernetes dashboard host
- include the redirect manifest in the dashboard kustomization

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ddf96f87888327bf92bee3671f948e