### PR TITLE
Fix admin ingress routing and correct users API function entries

### DIFF
--- a/platform/flux/platform/knative/kourier-traefik-ingressroutes.yaml
+++ b/platform/flux/platform/knative/kourier-traefik-ingressroutes.yaml
@@ -1,0 +1,28 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: kourier-admin-web
+  namespace: kourier-system
+spec:
+  entryPoints:
+    - web
+  routes:
+    - kind: Rule
+      match: Host(`admin.tessaro.dino.home`)
+      services:
+        - name: kourier
+          port: 80
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: kourier-admin-web-tls
+  namespace: kourier-system
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: HostSNI(`admin.tessaro.dino.home`)
+      services:
+        - name: kourier
+          port: 443

--- a/platform/flux/platform/knative/kustomization.yaml
+++ b/platform/flux/platform/knative/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - net-kourier-helmrelease.yaml
   - knative-eventing-helmrelease.yaml
   - knative-serving-domain-config.yaml
+  - kourier-traefik-ingressroutes.yaml

--- a/services/users-api/deploy/flux/users-api-get-service.yaml
+++ b/services/users-api/deploy/flux/users-api-get-service.yaml
@@ -22,7 +22,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: FUNCTION_ENTRY
-              value: apps/functions/users/src/knative-get-users.ts
+              value: services/users-api/functions/src/knative-get-users.ts
             - name: PORT
               value: "8080"
             - name: HOST

--- a/services/users-api/deploy/flux/users-api-post-service.yaml
+++ b/services/users-api/deploy/flux/users-api-post-service.yaml
@@ -22,7 +22,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: FUNCTION_ENTRY
-              value: apps/functions/users/src/knative-create-user.ts
+              value: services/users-api/functions/src/knative-create-user.ts
             - name: PORT
               value: "8080"
             - name: HOST


### PR DESCRIPTION
## Summary
- add Traefik ingress routes that forward admin.tessaro.dino.home traffic to the Kourier gateway
- update the knative kustomization to include the new ingress routing manifest
- correct the FUNCTION_ENTRY paths in the users API Knative services so they point at the actual source files

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68ddfce8fd2083279d68cc176ee7b0f2