### PR TITLE
fix: restore kubernetes dashboard access

### DIFF
--- a/kubernetes-dashboard-fix.md
+++ b/kubernetes-dashboard-fix.md
@@ -1,0 +1,14 @@
+# Kubernetes Dashboard 404 Remediation
+
+## Summary
+- Added the missing `kubernetes-dashboard` namespace so Flux can create dashboard resources.
+- Registered the official Kubernetes Dashboard Helm repository and release through Flux.
+- Updated the platform kustomization to apply the new Helm artifacts alongside the existing Traefik routes.
+
+## Deployment Notes
+1. Commit and push these changes to the repository.
+2. Trigger Flux to reconcile, for example:
+   ```bash
+   ./tools/scripts/reconcile-flux.sh platform
+   ```
+3. Once the reconciliation finishes, `https://kubernetes.tessaro.dino.home/` should load the dashboard instead of returning 404.

--- a/platform/flux/namespaces/namespaces.yaml
+++ b/platform/flux/namespaces/namespaces.yaml
@@ -53,3 +53,10 @@ metadata:
   name: kourier-system
   labels:
     app.kubernetes.io/name: kourier-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubernetes-dashboard
+  labels:
+    app.kubernetes.io/name: kubernetes-dashboard

--- a/platform/flux/platform/kubernetes-dashboard/kubernetes-dashboard-helmrelease.yaml
+++ b/platform/flux/platform/kubernetes-dashboard/kubernetes-dashboard-helmrelease.yaml
@@ -1,0 +1,24 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: kubernetes-dashboard
+  namespace: kubernetes-dashboard
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: kubernetes-dashboard
+      version: 4.12.0
+      sourceRef:
+        kind: HelmRepository
+        name: kubernetes-dashboard
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    nginx:
+      enabled: false

--- a/platform/flux/platform/kubernetes-dashboard/kubernetes-dashboard-helmrepository.yaml
+++ b/platform/flux/platform/kubernetes-dashboard/kubernetes-dashboard-helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: kubernetes-dashboard
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://kubernetes.github.io/dashboard/

--- a/platform/flux/platform/kubernetes-dashboard/kustomization.yaml
+++ b/platform/flux/platform/kubernetes-dashboard/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - kubernetes-dashboard-helmrepository.yaml
+  - kubernetes-dashboard-helmrelease.yaml
   - kubernetes-dashboard-ingressroute.yaml
   - kubernetes-dashboard-redirect.yaml


### PR DESCRIPTION
## Summary
- create the kubernetes-dashboard namespace so Flux can manage dashboard resources
- add Flux Helm repository and release definitions for the Kubernetes Dashboard and include them in kustomization
- document the remediation steps for resolving the 404 returned at https://kubernetes.tessaro.dino.home/

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de075314448327914dcbc29b33dc92