### PR TITLE
fix: restore legacy flux cluster path

### DIFF
--- a/infra/k8s/clusters/home/kustomization.yaml
+++ b/infra/k8s/clusters/home/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../platform/flux/clusters/home


### PR DESCRIPTION
## Summary
- add a compatibility kustomization at infra/k8s/clusters/home to match the legacy Flux sync path
- delegate the legacy kustomization to the new platform/flux layout so existing clusters reconcile successfully

## Testing
- not run (manifest-only change)


------
https://chatgpt.com/codex/tasks/task_e_68de0ea5de4083278950dd4b1c017842