### PR TITLE
fix: reconcile knative services after platform

### DIFF
--- a/platform/flux/clusters/home/admin-app-kustomization.yaml
+++ b/platform/flux/clusters/home/admin-app-kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: admin-app
+  namespace: flux-system
+spec:
+  interval: 5m
+  timeout: 3m
+  prune: true
+  wait: true
+  dependsOn:
+    - name: platform
+  path: ./services/admin-app/deploy/flux
+  sourceRef:
+    kind: GitRepository
+    name: tessaro

--- a/platform/flux/clusters/home/kustomization.yaml
+++ b/platform/flux/clusters/home/kustomization.yaml
@@ -5,6 +5,6 @@ resources:
   - ../../namespaces
   - ../../databases/scylla
   - ../../object-storage/minio
-  - ../../platform
-  - ../../../../services/users-api/deploy/flux
-  - ../../../../services/admin-app/deploy/flux
+  - platform-kustomization.yaml
+  - users-api-kustomization.yaml
+  - admin-app-kustomization.yaml

--- a/platform/flux/clusters/home/platform-kustomization.yaml
+++ b/platform/flux/clusters/home/platform-kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: platform
+  namespace: flux-system
+spec:
+  interval: 5m
+  timeout: 3m
+  prune: true
+  wait: true
+  path: ./platform/flux/platform
+  sourceRef:
+    kind: GitRepository
+    name: tessaro

--- a/platform/flux/clusters/home/users-api-kustomization.yaml
+++ b/platform/flux/clusters/home/users-api-kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: users-api
+  namespace: flux-system
+spec:
+  interval: 5m
+  timeout: 3m
+  prune: true
+  wait: true
+  dependsOn:
+    - name: platform
+  path: ./services/users-api/deploy/flux
+  sourceRef:
+    kind: GitRepository
+    name: tessaro


### PR DESCRIPTION
## Summary
- split the cluster sync so Flux applies the platform stack before app manifests
- add dedicated Flux Kustomizations for the users API and admin app that depend on the platform

## Testing
- not run (configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68de132dce2c8327bf101ec68f4570ff