### PR TITLE
feat: type database row mappings

### DIFF
--- a/services/orgs-api/functions/tests/org-service.test.ts
+++ b/services/orgs-api/functions/tests/org-service.test.ts
@@ -1,5 +1,6 @@
 import ConfigService from 'shared/libs/database/config-service';
 import ScyllaClient from 'shared/libs/database/scylla-client';
+import type { OrganizationRow, QueryResult } from 'shared/libs/database/types';
 
 // Mock ScyllaClient
 jest.mock('shared/libs/database/scylla-client');
@@ -7,6 +8,8 @@ jest.mock('shared/libs/database/scylla-client');
 describe('ConfigService', () => {
   let configService: ConfigService;
   let mockDbClient: jest.Mocked<ScyllaClient>;
+
+  const createResult = <TRow>(rows: TRow[]): QueryResult<TRow> => ({ rows });
 
   beforeEach(() => {
     const MockedScyllaClient = ScyllaClient as jest.MockedClass<typeof ScyllaClient>;
@@ -29,7 +32,7 @@ describe('ConfigService', () => {
         updated_at: expect.any(Date)
       };
 
-      mockDbClient.executeQuery.mockResolvedValueOnce({});
+      mockDbClient.executeQuery.mockResolvedValueOnce(createResult([]));
 
       const result = await configService.createOrganization(orgData);
 
@@ -44,7 +47,7 @@ describe('ConfigService', () => {
   describe('getOrganizationById', () => {
     it('should return an organization when found', async () => {
       const orgId = '123';
-      const orgData = {
+      const orgData: OrganizationRow = {
         id: orgId,
         name: 'Test Org',
         plan: 'enterprise',
@@ -53,9 +56,7 @@ describe('ConfigService', () => {
         updated_at: new Date()
       };
 
-      mockDbClient.executeQuery.mockResolvedValueOnce({
-        rows: [orgData]
-      });
+      mockDbClient.executeQuery.mockResolvedValueOnce(createResult([orgData]));
 
       const result = await configService.getOrganizationById(orgId);
 
@@ -69,9 +70,7 @@ describe('ConfigService', () => {
     it('should return null when organization is not found', async () => {
       const orgId = '123';
 
-      mockDbClient.executeQuery.mockResolvedValueOnce({
-        rows: []
-      });
+      mockDbClient.executeQuery.mockResolvedValueOnce(createResult([]));
 
       const result = await configService.getOrganizationById(orgId);
 
@@ -82,7 +81,7 @@ describe('ConfigService', () => {
   describe('updateOrganization', () => {
     it('should update and return the organization when found', async () => {
       const orgId = '123';
-      const existingOrg = {
+      const existingOrg: OrganizationRow = {
         id: orgId,
         name: 'Old Org',
         plan: 'basic',
@@ -103,12 +102,10 @@ describe('ConfigService', () => {
       };
 
       // Mock getOrganizationById
-      mockDbClient.executeQuery.mockResolvedValueOnce({
-        rows: [existingOrg]
-      });
+      mockDbClient.executeQuery.mockResolvedValueOnce(createResult([existingOrg]));
 
       // Mock updateOrganization
-      mockDbClient.executeQuery.mockResolvedValueOnce({});
+      mockDbClient.executeQuery.mockResolvedValueOnce(createResult([]));
 
       const result = await configService.updateOrganization(orgId, updates);
 
@@ -123,9 +120,7 @@ describe('ConfigService', () => {
       const orgId = '123';
       const updates = { name: 'New Name' };
 
-      mockDbClient.executeQuery.mockResolvedValueOnce({
-        rows: []
-      });
+      mockDbClient.executeQuery.mockResolvedValueOnce(createResult([]));
 
       const result = await configService.updateOrganization(orgId, updates);
 
@@ -137,7 +132,7 @@ describe('ConfigService', () => {
     it('should delete an organization', async () => {
       const orgId = '123';
 
-      mockDbClient.executeQuery.mockResolvedValueOnce({});
+      mockDbClient.executeQuery.mockResolvedValueOnce(createResult([]));
 
       await configService.deleteOrganization(orgId);
 

--- a/services/services-api/functions/tests/service-service.test.ts
+++ b/services/services-api/functions/tests/service-service.test.ts
@@ -1,5 +1,6 @@
 import ConfigService from 'shared/libs/database/config-service';
 import ScyllaClient from 'shared/libs/database/scylla-client';
+import type { QueryResult, ServiceRow } from 'shared/libs/database/types';
 
 // Mock ScyllaClient
 jest.mock('shared/libs/database/scylla-client');
@@ -7,6 +8,8 @@ jest.mock('shared/libs/database/scylla-client');
 describe('ConfigService - Service Management', () => {
   let configService: ConfigService;
   let mockDbClient: jest.Mocked<ScyllaClient>;
+
+  const createResult = <TRow>(rows: TRow[]): QueryResult<TRow> => ({ rows });
 
   beforeEach(() => {
     const MockedScyllaClient = ScyllaClient as jest.MockedClass<typeof ScyllaClient>;
@@ -29,7 +32,7 @@ describe('ConfigService - Service Management', () => {
         updated_at: expect.any(Date)
       };
 
-      mockDbClient.executeQuery.mockResolvedValueOnce({});
+      mockDbClient.executeQuery.mockResolvedValueOnce(createResult([]));
 
       const result = await configService.createService(serviceData);
 
@@ -44,7 +47,7 @@ describe('ConfigService - Service Management', () => {
   describe('getServiceById', () => {
     it('should return a service when found', async () => {
       const serviceId = '123';
-      const serviceData = {
+      const serviceData: ServiceRow = {
         id: serviceId,
         name: 'Email Service',
         type: 'communication',
@@ -53,9 +56,7 @@ describe('ConfigService - Service Management', () => {
         updated_at: new Date()
       };
 
-      mockDbClient.executeQuery.mockResolvedValueOnce({
-        rows: [serviceData]
-      });
+      mockDbClient.executeQuery.mockResolvedValueOnce(createResult([serviceData]));
 
       const result = await configService.getServiceById(serviceId);
 
@@ -69,9 +70,7 @@ describe('ConfigService - Service Management', () => {
     it('should return null when service is not found', async () => {
       const serviceId = '123';
 
-      mockDbClient.executeQuery.mockResolvedValueOnce({
-        rows: []
-      });
+      mockDbClient.executeQuery.mockResolvedValueOnce(createResult([]));
 
       const result = await configService.getServiceById(serviceId);
 
@@ -82,7 +81,7 @@ describe('ConfigService - Service Management', () => {
   describe('updateService', () => {
     it('should update and return the service when found', async () => {
       const serviceId = '123';
-      const existingService = {
+      const existingService: ServiceRow = {
         id: serviceId,
         name: 'Old Service',
         type: 'old-type',
@@ -103,12 +102,10 @@ describe('ConfigService - Service Management', () => {
       };
 
       // Mock getServiceById
-      mockDbClient.executeQuery.mockResolvedValueOnce({
-        rows: [existingService]
-      });
+      mockDbClient.executeQuery.mockResolvedValueOnce(createResult([existingService]));
 
       // Mock updateService
-      mockDbClient.executeQuery.mockResolvedValueOnce({});
+      mockDbClient.executeQuery.mockResolvedValueOnce(createResult([]));
 
       const result = await configService.updateService(serviceId, updates);
 
@@ -123,9 +120,7 @@ describe('ConfigService - Service Management', () => {
       const serviceId = '123';
       const updates = { name: 'New Service' };
 
-      mockDbClient.executeQuery.mockResolvedValueOnce({
-        rows: []
-      });
+      mockDbClient.executeQuery.mockResolvedValueOnce(createResult([]));
 
       const result = await configService.updateService(serviceId, updates);
 
@@ -137,7 +132,7 @@ describe('ConfigService - Service Management', () => {
     it('should delete a service', async () => {
       const serviceId = '123';
 
-      mockDbClient.executeQuery.mockResolvedValueOnce({});
+      mockDbClient.executeQuery.mockResolvedValueOnce(createResult([]));
 
       await configService.deleteService(serviceId);
 

--- a/services/users-api/functions/tests/user-service.test.ts
+++ b/services/users-api/functions/tests/user-service.test.ts
@@ -1,5 +1,6 @@
 import UserService from 'shared/libs/database/user-service';
 import ScyllaClient from 'shared/libs/database/scylla-client';
+import type { QueryResult, UserRow } from 'shared/libs/database/types';
 
 // Mock ScyllaClient
 jest.mock('shared/libs/database/scylla-client');
@@ -7,6 +8,8 @@ jest.mock('shared/libs/database/scylla-client');
 describe('UserService', () => {
   let userService: UserService;
   let mockDbClient: jest.Mocked<ScyllaClient>;
+
+  const createResult = <TRow>(rows: TRow[]): QueryResult<TRow> => ({ rows });
 
   beforeEach(() => {
     const MockedScyllaClient = ScyllaClient as jest.MockedClass<typeof ScyllaClient>;
@@ -29,7 +32,7 @@ describe('UserService', () => {
         updated_at: expect.any(Date)
       };
 
-      mockDbClient.executeQuery.mockResolvedValueOnce({});
+      mockDbClient.executeQuery.mockResolvedValueOnce(createResult([]));
 
       const result = await userService.createUser(userData);
 
@@ -44,18 +47,17 @@ describe('UserService', () => {
   describe('getUserById', () => {
     it('should return a user when found', async () => {
       const userId = '123';
-      const userData = {
+      const userData: UserRow = {
         id: userId,
         email: 'test@example.com',
         name: 'Test User',
         role: 'user',
+        avatar_url: null,
         created_at: new Date(),
         updated_at: new Date()
       };
 
-      mockDbClient.executeQuery.mockResolvedValueOnce({
-        rows: [userData]
-      });
+      mockDbClient.executeQuery.mockResolvedValueOnce(createResult([userData]));
 
       const result = await userService.getUserById(userId);
 
@@ -69,9 +71,7 @@ describe('UserService', () => {
     it('should return null when user is not found', async () => {
       const userId = '123';
 
-      mockDbClient.executeQuery.mockResolvedValueOnce({
-        rows: []
-      });
+      mockDbClient.executeQuery.mockResolvedValueOnce(createResult([]));
 
       const result = await userService.getUserById(userId);
 
@@ -81,7 +81,7 @@ describe('UserService', () => {
 
   describe('listUsers', () => {
     it('should return a list of users', async () => {
-      const users = [
+      const users: UserRow[] = [
         {
           id: '1',
           email: 'one@example.com',
@@ -102,7 +102,7 @@ describe('UserService', () => {
         }
       ];
 
-      mockDbClient.executeQuery.mockResolvedValueOnce({ rows: users });
+      mockDbClient.executeQuery.mockResolvedValueOnce(createResult(users));
 
       const result = await userService.listUsers();
 
@@ -114,11 +114,12 @@ describe('UserService', () => {
   describe('updateUser', () => {
     it('should update and return the user when found', async () => {
       const userId = '123';
-      const existingUser = {
+      const existingUser: UserRow = {
         id: userId,
         email: 'old@example.com',
         name: 'Old Name',
         role: 'user',
+        avatar_url: null,
         created_at: new Date(),
         updated_at: new Date()
       };
@@ -135,12 +136,10 @@ describe('UserService', () => {
       };
 
       // Mock getUserById
-      mockDbClient.executeQuery.mockResolvedValueOnce({
-        rows: [existingUser]
-      });
+      mockDbClient.executeQuery.mockResolvedValueOnce(createResult([existingUser]));
 
       // Mock updateUser
-      mockDbClient.executeQuery.mockResolvedValueOnce({});
+      mockDbClient.executeQuery.mockResolvedValueOnce(createResult([]));
 
       const result = await userService.updateUser(userId, updates);
 
@@ -155,9 +154,7 @@ describe('UserService', () => {
       const userId = '123';
       const updates = { name: 'New Name' };
 
-      mockDbClient.executeQuery.mockResolvedValueOnce({
-        rows: []
-      });
+      mockDbClient.executeQuery.mockResolvedValueOnce(createResult([]));
 
       const result = await userService.updateUser(userId, updates);
 
@@ -169,7 +166,7 @@ describe('UserService', () => {
     it('should delete a user', async () => {
       const userId = '123';
 
-      mockDbClient.executeQuery.mockResolvedValueOnce({});
+      mockDbClient.executeQuery.mockResolvedValueOnce(createResult([]));
 
       await userService.deleteUser(userId);
 

--- a/shared/libs/database/src/config-service.ts
+++ b/shared/libs/database/src/config-service.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import ScyllaClient from './scylla-client';
-import { ScyllaConfig, Organization, Service } from './types';
+import { ScyllaConfig, Organization, OrganizationRow, Service, ServiceRow } from './types';
 
 class ConfigService {
   constructor(private dbClient: ScyllaClient) {}
@@ -28,7 +28,7 @@ class ConfigService {
 
   async getOrganizationById(id: string): Promise<Organization | null> {
     const query = `SELECT * FROM organizations WHERE id = ?`;
-    const result = await this.dbClient.executeQuery(query, [id]);
+    const result = await this.dbClient.executeQuery<OrganizationRow>(query, [id]);
     
     if (result.rows.length === 0) {
       return null;
@@ -89,7 +89,7 @@ class ConfigService {
 
   async getServiceById(id: string): Promise<Service | null> {
     const query = `SELECT * FROM services WHERE id = ?`;
-    const result = await this.dbClient.executeQuery(query, [id]);
+    const result = await this.dbClient.executeQuery<ServiceRow>(query, [id]);
     
     if (result.rows.length === 0) {
       return null;
@@ -131,7 +131,7 @@ class ConfigService {
     return uuidv4();
   }
 
-  private mapRowToOrganization(row: any): Organization {
+  private mapRowToOrganization(row: OrganizationRow): Organization {
     return {
       id: row.id,
       name: row.name,
@@ -142,7 +142,7 @@ class ConfigService {
     };
   }
 
-  private mapRowToService(row: any): Service {
+  private mapRowToService(row: ServiceRow): Service {
     return {
       id: row.id,
       name: row.name,

--- a/shared/libs/database/src/scylla-client.ts
+++ b/shared/libs/database/src/scylla-client.ts
@@ -1,5 +1,5 @@
 import { Client, auth } from 'cassandra-driver';
-import { ScyllaConfig } from './types';
+import { QueryResult, ScyllaConfig } from './types';
 
 class ScyllaClient {
   private client: Client;
@@ -32,11 +32,11 @@ class ScyllaClient {
     }
   }
 
-  async executeQuery(query: string, params?: any[]): Promise<any> {
+  async executeQuery<TRow = Record<string, unknown>>(query: string, params?: any[]): Promise<QueryResult<TRow>> {
     if (!this.connected) {
       await this.connect();
     }
-    return this.client.execute(query, params);
+    return this.client.execute(query, params) as unknown as QueryResult<TRow>;
   }
 
   async executeBatch(queries: Array<{query: string, params?: any[]}>): Promise<any> {

--- a/shared/libs/database/src/types.ts
+++ b/shared/libs/database/src/types.ts
@@ -1,5 +1,10 @@
 import { auth } from 'cassandra-driver';
 
+export interface QueryResult<TRow> {
+  rows: TRow[];
+  [key: string]: unknown;
+}
+
 export interface ScyllaConfig {
   contactPoints: string[];
   localDataCenter: string;
@@ -15,7 +20,17 @@ export interface UserProfile {
   email: string;
   name: string;
   role: string;
-  avatar_url?: string;
+  avatar_url?: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface UserRow {
+  id: string;
+  email: string;
+  name: string;
+  role: string;
+  avatar_url: string | null;
   created_at: Date;
   updated_at: Date;
 }
@@ -29,7 +44,25 @@ export interface Organization {
   updated_at: Date;
 }
 
+export interface OrganizationRow {
+  id: string;
+  name: string;
+  plan: string;
+  status: string;
+  created_at: Date;
+  updated_at: Date;
+}
+
 export interface Service {
+  id: string;
+  name: string;
+  type: string;
+  status: string;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface ServiceRow {
   id: string;
   name: string;
   type: string;

--- a/shared/libs/database/src/user-service.ts
+++ b/shared/libs/database/src/user-service.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import ScyllaClient from './scylla-client';
-import { ScyllaConfig, UserProfile, Organization, Service, AuditLog } from './types';
+import { ScyllaConfig, UserProfile, Organization, Service, AuditLog, UserRow } from './types';
 
 class UserService {
   constructor(private dbClient: ScyllaClient) {}
@@ -29,7 +29,7 @@ class UserService {
 
   async getUserById(id: string): Promise<UserProfile | null> {
     const query = `SELECT * FROM users WHERE id = ?`;
-    const result = await this.dbClient.executeQuery(query, [id]);
+    const result = await this.dbClient.executeQuery<UserRow>(query, [id]);
     
     if (result.rows.length === 0) {
       return null;
@@ -40,9 +40,9 @@ class UserService {
 
   async listUsers(): Promise<UserProfile[]> {
     const query = 'SELECT * FROM users';
-    const result = await this.dbClient.executeQuery(query);
+    const result = await this.dbClient.executeQuery<UserRow>(query);
 
-    return result.rows.map((row: any) => this.mapRowToUser(row));
+    return result.rows.map((row) => this.mapRowToUser(row));
   }
 
   async updateUser(id: string, updates: Partial<Omit<UserProfile, 'id' | 'created_at' | 'updated_at'>>): Promise<UserProfile | null> {
@@ -79,7 +79,7 @@ class UserService {
     return uuidv4();
   }
 
-  private mapRowToUser(row: any): UserProfile {
+  private mapRowToUser(row: UserRow): UserProfile {
     return {
       id: row.id,
       email: row.email,


### PR DESCRIPTION
## Summary
- add typed row interfaces and a query result helper for Scylla rows
- update database services to use strongly typed Cassandra rows
- adjust service tests to rely on typed fixtures for compile-time schema checks

## Testing
- npm test -- --runTestsByPath services/users-api/functions/tests/user-service.test.ts services/orgs-api/functions/tests/org-service.test.ts services/services-api/functions/tests/service-service.test.ts --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68de1506bff88327bffdbe293bb45315