### PR TITLE
fix: extend flux reconciliation timeouts

### DIFF
--- a/platform/flux/clusters/home/admin-app-kustomization.yaml
+++ b/platform/flux/clusters/home/admin-app-kustomization.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 5m
-  timeout: 3m
+  timeout: 10m
   prune: true
   wait: true
   dependsOn:

--- a/platform/flux/clusters/home/flux-system/gotk-sync.yaml
+++ b/platform/flux/clusters/home/flux-system/gotk-sync.yaml
@@ -18,7 +18,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 5m
-  timeout: 3m
+  timeout: 10m
   prune: true
   wait: true
   sourceRef:

--- a/platform/flux/clusters/home/platform-kustomization.yaml
+++ b/platform/flux/clusters/home/platform-kustomization.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 5m
-  timeout: 3m
+  timeout: 10m
   prune: true
   wait: true
   path: ./platform/flux/platform

--- a/platform/flux/clusters/home/users-api-kustomization.yaml
+++ b/platform/flux/clusters/home/users-api-kustomization.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 5m
-  timeout: 3m
+  timeout: 10m
   prune: true
   wait: true
   dependsOn:


### PR DESCRIPTION
## Summary
- extend the platform, users-api, and admin-app Flux kustomization timeouts to 10 minutes so longer rollouts can complete
- raise the tessaro-cluster reconciliation timeout to 10 minutes to accommodate the downstream changes

## Testing
- not run (infrastructure manifest change)


------
https://chatgpt.com/codex/tasks/task_e_68de1822459883279dfd53026344bed8