### PR TITLE
Update Flux manifests to reference GHCR images

### DIFF
--- a/services/admin-app/deploy/flux/admin-service.yaml
+++ b/services/admin-app/deploy/flux/admin-service.yaml
@@ -18,8 +18,8 @@ spec:
       timeoutSeconds: 30
       containers:
         - name: admin-web
-          image: ttl.sh/tessaro-admin-1e9243e44cdf4934bf99b6ddf5cd706b:24h
-          imagePullPolicy: Always
+          image: ghcr.io/your-org/tessaro-admin-web@sha256:REPLACE_WITH_DIGEST
+          imagePullPolicy: IfNotPresent
           env:
             - name: VITE_USERS_API_URL
               valueFrom:

--- a/services/users-api/deploy/flux/users-api-deployment.yaml
+++ b/services/users-api/deploy/flux/users-api-deployment.yaml
@@ -19,8 +19,8 @@ spec:
     spec:
       containers:
         - name: users-api
-          image: ttl.sh/tessaro-users-api-4152c5b4f1b04ac9ba34fa797a646e1e:24h
-          imagePullPolicy: Always
+          image: ghcr.io/your-org/tessaro-users-api@sha256:REPLACE_WITH_DIGEST
+          imagePullPolicy: IfNotPresent
           env:
             - name: PORT
               value: "4000"

--- a/services/users-api/deploy/flux/users-api-get-service.yaml
+++ b/services/users-api/deploy/flux/users-api-get-service.yaml
@@ -18,8 +18,8 @@ spec:
       timeoutSeconds: 30
       containers:
         - name: users-api-get
-          image: ttl.sh/tessaro-users-api-get-knative:24h
-          imagePullPolicy: Always
+          image: ghcr.io/your-org/tessaro-users-api-get@sha256:REPLACE_WITH_DIGEST
+          imagePullPolicy: IfNotPresent
           env:
             - name: FUNCTION_ENTRY
               value: services/users-api/functions/src/knative-get-users.ts

--- a/services/users-api/deploy/flux/users-api-post-service.yaml
+++ b/services/users-api/deploy/flux/users-api-post-service.yaml
@@ -18,8 +18,8 @@ spec:
       timeoutSeconds: 30
       containers:
         - name: users-api-post
-          image: ttl.sh/tessaro-users-api-post-knative:24h
-          imagePullPolicy: Always
+          image: ghcr.io/your-org/tessaro-users-api-post@sha256:REPLACE_WITH_DIGEST
+          imagePullPolicy: IfNotPresent
           env:
             - name: FUNCTION_ENTRY
               value: services/users-api/functions/src/knative-create-user.ts


### PR DESCRIPTION
## Summary
- update admin and users API Flux manifests to point at GHCR-hosted images
- switch imagePullPolicy to IfNotPresent now that digests will be used

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deb22eaaf88327b42a0a6af331ed0c