### PR TITLE
fix: update metrics-server deployment for v0.7.2

### DIFF
--- a/platform/flux/platform/metrics-server/metrics-server.yaml
+++ b/platform/flux/platform/metrics-server/metrics-server.yaml
@@ -133,12 +133,11 @@ spec:
       containers:
         - args:
             - --cert-dir=/tmp
-            - --secure-port=4443
-            - --kubelet-insecure-tls
+            - --secure-port=10250
             - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
             - --kubelet-use-node-status-port
             - --metric-resolution=15s
-          image: registry.k8s.io/metrics-server/metrics-server:v0.6.4
+          image: registry.k8s.io/metrics-server/metrics-server:v0.7.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -149,7 +148,7 @@ spec:
             periodSeconds: 10
           name: metrics-server
           ports:
-            - containerPort: 4443
+            - containerPort: 10250
               name: https
               protocol: TCP
           readinessProbe:
@@ -166,9 +165,14 @@ spec:
               memory: 200Mi
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
           volumeMounts:
             - mountPath: /tmp
               name: tmp-dir


### PR DESCRIPTION
## Summary
- bump the metrics-server deployment to image v0.7.2
- update container arguments, port, and security context to match the new release requirements

## Testing
- ./tools/scripts/reconcile-flux.sh platform *(fails: flux CLI is required but was not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68deb23d72a48327bcb2c19dcb3b2428