### PR TITLE
fix: use persistent registry images and tune metrics server

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,22 @@ Then set `VITE_USERS_API_URL=http://localhost:8080` when starting the admin app.
 > **NEVER** run commands directly on the Kubernetes cluster. **ONLY** update the manifests in this repository,
 > commit the change, and reconcile Flux to apply it. Once you've made changes, push to a new branch and create a PR.
 
+### Building and publishing container images
+
+First-party services now pull images from the in-cluster registry at `registry.tessaro.dino.home`.
+Use the helper script below to build and push the admin web and users API images before
+triggering a Flux reconciliation:
+
+```bash
+./tools/scripts/publish-images.sh
+```
+
+Override the target registry host or version tag if needed:
+
+```bash
+REGISTRY_HOST=registry.tessaro.example.com VERSION=v0.1.1 ./tools/scripts/publish-images.sh
+```
+
 ### Reconciliation workflow
 
 1. Update the desired manifests under `platform/flux`.

--- a/platform/flux/platform/metrics-server/metrics-server.yaml
+++ b/platform/flux/platform/metrics-server/metrics-server.yaml
@@ -133,7 +133,8 @@ spec:
       containers:
         - args:
             - --cert-dir=/tmp
-            - --secure-port=10250
+            - --secure-port=4443
+            - --kubelet-insecure-tls
             - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
             - --kubelet-use-node-status-port
             - --metric-resolution=15s
@@ -148,7 +149,7 @@ spec:
             periodSeconds: 10
           name: metrics-server
           ports:
-            - containerPort: 10250
+            - containerPort: 4443
               name: https
               protocol: TCP
           readinessProbe:

--- a/services/admin-app/deploy/flux/admin-service.yaml
+++ b/services/admin-app/deploy/flux/admin-service.yaml
@@ -18,8 +18,8 @@ spec:
       timeoutSeconds: 30
       containers:
         - name: admin-web
-          image: ttl.sh/tessaro-admin-1e9243e44cdf4934bf99b6ddf5cd706b:24h
-          imagePullPolicy: Always
+          image: registry.tessaro.dino.home/apps/admin-web:v0.1.0
+          imagePullPolicy: IfNotPresent
           env:
             - name: VITE_USERS_API_URL
               valueFrom:

--- a/services/users-api/deploy/flux/users-api-deployment.yaml
+++ b/services/users-api/deploy/flux/users-api-deployment.yaml
@@ -19,8 +19,8 @@ spec:
     spec:
       containers:
         - name: users-api
-          image: ttl.sh/tessaro-users-api-4152c5b4f1b04ac9ba34fa797a646e1e:24h
-          imagePullPolicy: Always
+          image: registry.tessaro.dino.home/apps/users-api:v0.1.0
+          imagePullPolicy: IfNotPresent
           env:
             - name: PORT
               value: "4000"

--- a/services/users-api/deploy/flux/users-api-get-service.yaml
+++ b/services/users-api/deploy/flux/users-api-get-service.yaml
@@ -18,8 +18,8 @@ spec:
       timeoutSeconds: 30
       containers:
         - name: users-api-get
-          image: ttl.sh/tessaro-users-api-get-knative:24h
-          imagePullPolicy: Always
+          image: registry.tessaro.dino.home/apps/users-api-knative:v0.1.0
+          imagePullPolicy: IfNotPresent
           env:
             - name: FUNCTION_ENTRY
               value: services/users-api/functions/src/knative-get-users.ts

--- a/services/users-api/deploy/flux/users-api-post-service.yaml
+++ b/services/users-api/deploy/flux/users-api-post-service.yaml
@@ -18,8 +18,8 @@ spec:
       timeoutSeconds: 30
       containers:
         - name: users-api-post
-          image: ttl.sh/tessaro-users-api-post-knative:24h
-          imagePullPolicy: Always
+          image: registry.tessaro.dino.home/apps/users-api-knative:v0.1.0
+          imagePullPolicy: IfNotPresent
           env:
             - name: FUNCTION_ENTRY
               value: services/users-api/functions/src/knative-create-user.ts

--- a/tools/scripts/publish-images.sh
+++ b/tools/scripts/publish-images.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REGISTRY_HOST=${REGISTRY_HOST:-registry.tessaro.dino.home}
+VERSION=${VERSION:-v0.1.0}
+ADMIN_IMAGE="${REGISTRY_HOST}/apps/admin-web:${VERSION}"
+USERS_API_IMAGE="${REGISTRY_HOST}/apps/users-api:${VERSION}"
+USERS_API_KNATIVE_IMAGE="${REGISTRY_HOST}/apps/users-api-knative:${VERSION}"
+
+build_and_push() {
+  local image="$1"
+  local dockerfile="$2"
+  local context="$3"
+
+  echo "Building ${image} from ${dockerfile}" >&2
+  DOCKER_BUILDKIT=1 docker build \
+    -f "${dockerfile}" \
+    -t "${image}" \
+    "${context}"
+
+  echo "Pushing ${image}" >&2
+  docker push "${image}"
+}
+
+main() {
+  build_and_push "${ADMIN_IMAGE}" "${ROOT_DIR}/services/admin-app/app/Dockerfile" "${ROOT_DIR}"
+
+  build_and_push "${USERS_API_IMAGE}" "${ROOT_DIR}/services/users-api/functions/Dockerfile" "${ROOT_DIR}"
+
+  echo "Tagging ${USERS_API_IMAGE} as ${USERS_API_KNATIVE_IMAGE}" >&2
+  docker tag "${USERS_API_IMAGE}" "${USERS_API_KNATIVE_IMAGE}"
+  echo "Pushing ${USERS_API_KNATIVE_IMAGE}" >&2
+  docker push "${USERS_API_KNATIVE_IMAGE}"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- point the admin web and users API manifests at long-lived images in the in-cluster registry
- add a helper script and documentation for building and publishing those images
- adjust the metrics server deployment to serve on the standard port with relaxed kubelet TLS so HPAs can read metrics

## Testing
- not run (infrastructure manifest updates only)

------
https://chatgpt.com/codex/tasks/task_e_68dec48be64883279fc831aaef2dd0b2