### PR TITLE
fix: clear stale auth session when verification fails

### DIFF
--- a/services/admin-app/app/tests/auth-context.test.tsx
+++ b/services/admin-app/app/tests/auth-context.test.tsx
@@ -98,6 +98,24 @@ describe('AuthContext', () => {
     expect(result.current.isAuthenticated).toBe(true);
   });
 
+  it('clears the cached session when restoration fails verification', async () => {
+    const staleSession = buildSession({ token: 'stale-token' });
+    authServiceMock.getSession.mockReturnValue(staleSession);
+    authServiceMock.restore.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useAuthContext(), { wrapper });
+
+    expect(result.current.session).toEqual(staleSession);
+    expect(result.current.isAuthenticated).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.initializing).toBe(false);
+    });
+
+    expect(result.current.session).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
   it('logs in and stores the resulting session', async () => {
     const loginSession = buildSession({
       token: 'next-token',

--- a/shared/libs/auth/src/auth-service.ts
+++ b/shared/libs/auth/src/auth-service.ts
@@ -57,12 +57,14 @@ export class AuthService {
         this.setSession(verified);
         return verified;
       }
+
+      this.clearSession();
+      return null;
     } catch (error) {
       console.warn('Failed to verify stored session', error);
+      this.clearSession();
+      return null;
     }
-
-    this.setSession(stored);
-    return stored;
   }
 
   private setSession(next: AuthSession): void {

--- a/shared/libs/auth/tests/auth-service.test.ts
+++ b/shared/libs/auth/tests/auth-service.test.ts
@@ -1,0 +1,94 @@
+import { AuthService } from '../src/auth-service';
+import { AuthGateway } from '../src/auth-gateway';
+import { AuthStorage } from '../src/auth-storage';
+import { AuthSession } from '../src/types';
+
+describe('AuthService.restore', () => {
+  const buildSession = (overrides: Partial<AuthSession> = {}): AuthSession => ({
+    token: 'session-token',
+    issuedAt: '2024-01-01T00:00:00.000Z',
+    user: {
+      id: 'admin-1',
+      email: 'admin@example.com',
+      name: 'Admin User',
+      role: 'administrator'
+    },
+    ...overrides
+  });
+
+  const createService = (
+    gatewayOverrides: Partial<jest.Mocked<AuthGateway>> = {},
+    storageOverrides: Partial<jest.Mocked<AuthStorage>> = {}
+  ) => {
+    const gateway: jest.Mocked<AuthGateway> = {
+      login: jest.fn(),
+      logout: jest.fn(),
+      verifySession: jest.fn(),
+      ...gatewayOverrides
+    };
+
+    const storage: jest.Mocked<AuthStorage> = {
+      load: jest.fn(),
+      save: jest.fn(),
+      clear: jest.fn(),
+      ...storageOverrides
+    };
+
+    return { service: new AuthService(gateway, storage), gateway, storage };
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('clears the stored session when verification returns null', async () => {
+    const storedSession = buildSession();
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { service, gateway, storage } = createService({
+      verifySession: jest.fn().mockResolvedValue(null)
+    }, {
+      load: jest.fn().mockReturnValue(storedSession)
+    });
+
+    const listener = jest.fn();
+    service.subscribe(listener);
+
+    expect(service.getSession()).toEqual(storedSession);
+
+    const restored = await service.restore();
+
+    expect(restored).toBeNull();
+    expect(gateway.verifySession).toHaveBeenCalledWith(storedSession.token);
+    expect(storage.clear).toHaveBeenCalledTimes(1);
+    expect(service.getSession()).toBeNull();
+    expect(listener).toHaveBeenLastCalledWith(null);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('clears the stored session when verification throws', async () => {
+    const storedSession = buildSession({ token: 'stale-token' });
+    const error = new Error('network-failure');
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { service, gateway, storage } = createService({
+      verifySession: jest.fn().mockRejectedValue(error)
+    }, {
+      load: jest.fn().mockReturnValue(storedSession)
+    });
+
+    const listener = jest.fn();
+    service.subscribe(listener);
+
+    expect(service.getSession()).toEqual(storedSession);
+
+    const restored = await service.restore();
+
+    expect(restored).toBeNull();
+    expect(gateway.verifySession).toHaveBeenCalledWith(storedSession.token);
+    expect(storage.clear).toHaveBeenCalledTimes(1);
+    expect(service.getSession()).toBeNull();
+    expect(listener).toHaveBeenLastCalledWith(null);
+    expect(warnSpy).toHaveBeenCalledWith('Failed to verify stored session', error);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the auth service clears stored sessions when verification fails or throws
- cover the auth context behavior for unverifiable cached sessions
- add auth service unit tests for failed verification scenarios

## Testing
- CI=1 npm test -- --runTestsByPath shared/libs/auth/tests/auth-service.test.ts services/admin-app/app/tests/auth-context.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dffc392ccc8327bacf66194fbfa777