### PR TITLE
fix: ensure type definitions for cors and mime-types

### DIFF
--- a/shared/config/app.ts
+++ b/shared/config/app.ts
@@ -1,11 +1,5 @@
 import express, { Express } from 'express';
-import cors from 'cors';
-
-type CorsOrigin = boolean | string | RegExp | Array<string | RegExp>;
-
-type CorsOptions = {
-  origin: CorsOrigin;
-};
+import cors, { CorsOptions } from 'cors';
 
 export const resolveCorsOptions = (): CorsOptions => {
   const allowedOrigins = process.env.CORS_ALLOWED_ORIGINS;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "jsx": "react-jsx",
-    "types": ["jest", "node", "@testing-library/jest-dom", "cors"],
+    "types": ["jest", "node", "@testing-library/jest-dom", "cors", "mime-types"],
     "baseUrl": ".",
     "paths": {
       "shared/libs/database": ["shared/libs/database/src"],


### PR DESCRIPTION
## Summary
- allow ts-jest to pick up the mime-types declaration files by including the package in the shared tsconfig
- rely on the official CorsOptions type from cors instead of a locally declared substitute

## Testing
- npm test -- --runTestsByPath services/storage-service/functions/tests/storage-service.test.ts shared/config/tests/app.test.ts --reporters=default

------
https://chatgpt.com/codex/tasks/task_e_68dfff56fe148327ad69131779600596