### PR TITLE
test: expand auth service coverage

### DIFF
--- a/shared/libs/auth/tests/auth-service.test.ts
+++ b/shared/libs/auth/tests/auth-service.test.ts
@@ -3,92 +3,170 @@ import { AuthGateway } from '../src/auth-gateway';
 import { AuthStorage } from '../src/auth-storage';
 import { AuthSession } from '../src/types';
 
-describe('AuthService.restore', () => {
-  const buildSession = (overrides: Partial<AuthSession> = {}): AuthSession => ({
-    token: 'session-token',
-    issuedAt: '2024-01-01T00:00:00.000Z',
-    user: {
-      id: 'admin-1',
-      email: 'admin@example.com',
-      name: 'Admin User',
-      role: 'administrator'
-    },
-    ...overrides
-  });
+const buildSession = (overrides: Partial<AuthSession> = {}): AuthSession => ({
+  token: 'session-token',
+  issuedAt: '2024-01-01T00:00:00.000Z',
+  user: {
+    id: 'admin-1',
+    email: 'admin@example.com',
+    name: 'Admin User',
+    role: 'administrator'
+  },
+  ...overrides
+});
 
-  const createService = (
-    gatewayOverrides: Partial<jest.Mocked<AuthGateway>> = {},
-    storageOverrides: Partial<jest.Mocked<AuthStorage>> = {}
-  ) => {
-    const gateway: jest.Mocked<AuthGateway> = {
-      login: jest.fn(),
-      logout: jest.fn(),
-      verifySession: jest.fn(),
-      ...gatewayOverrides
-    };
-
-    const storage: jest.Mocked<AuthStorage> = {
-      load: jest.fn(),
-      save: jest.fn(),
-      clear: jest.fn(),
-      ...storageOverrides
-    };
-
-    return { service: new AuthService(gateway, storage), gateway, storage };
+const createService = (
+  gatewayOverrides: Partial<jest.Mocked<AuthGateway>> = {},
+  storageOverrides: Partial<jest.Mocked<AuthStorage>> = {}
+) => {
+  const gateway: jest.Mocked<AuthGateway> = {
+    login: jest.fn(),
+    logout: jest.fn(),
+    verifySession: jest.fn(),
+    ...gatewayOverrides
   };
 
+  const storage: jest.Mocked<AuthStorage> = {
+    load: jest.fn(),
+    save: jest.fn(),
+    clear: jest.fn(),
+    ...storageOverrides
+  };
+
+  return { service: new AuthService(gateway, storage), gateway, storage };
+};
+
+describe('AuthService', () => {
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
-  it('clears the stored session when verification returns null', async () => {
-    const storedSession = buildSession();
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  describe('core behaviors', () => {
+    it('initializes from storage and notifies subscribers', async () => {
+      const storedSession = buildSession();
+      const { service, storage, gateway } = createService({
+        logout: jest.fn().mockResolvedValue(undefined)
+      }, {
+        load: jest.fn().mockReturnValue(storedSession)
+      });
 
-    const { service, gateway, storage } = createService({
-      verifySession: jest.fn().mockResolvedValue(null)
-    }, {
-      load: jest.fn().mockReturnValue(storedSession)
+      const listener = jest.fn();
+      const unsubscribe = service.subscribe(listener);
+
+      expect(storage.load).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith(storedSession);
+      expect(service.getSession()).toEqual(storedSession);
+      expect(service.isAuthenticated()).toBe(true);
+
+      unsubscribe();
+      listener.mockClear();
+
+      await service.logout();
+
+      expect(gateway.logout).toHaveBeenCalledWith(storedSession.token);
+      expect(listener).not.toHaveBeenCalled();
     });
 
-    const listener = jest.fn();
-    service.subscribe(listener);
+    it('logs in via the gateway and persists the new session', async () => {
+      const newSession = buildSession({ token: 'fresh-token' });
+      const credentials = { email: 'admin@example.com', password: 'secret' };
+      const { service, gateway, storage } = createService({
+        login: jest.fn().mockResolvedValue(newSession)
+      }, {
+        load: jest.fn().mockReturnValue(null)
+      });
 
-    expect(service.getSession()).toEqual(storedSession);
+      const listener = jest.fn();
+      service.subscribe(listener);
+      listener.mockClear();
 
-    const restored = await service.restore();
+      await service.login(credentials);
 
-    expect(restored).toBeNull();
-    expect(gateway.verifySession).toHaveBeenCalledWith(storedSession.token);
-    expect(storage.clear).toHaveBeenCalledTimes(1);
-    expect(service.getSession()).toBeNull();
-    expect(listener).toHaveBeenLastCalledWith(null);
-    expect(warnSpy).not.toHaveBeenCalled();
+      expect(gateway.login).toHaveBeenCalledWith(credentials);
+      expect(storage.save).toHaveBeenCalledWith(newSession);
+      expect(listener).toHaveBeenLastCalledWith(newSession);
+      expect(service.getSession()).toEqual(newSession);
+      expect(service.isAuthenticated()).toBe(true);
+    });
+
+    it('logs out, clears storage, and notifies subscribers', async () => {
+      const storedSession = buildSession({ token: 'persisted-token' });
+      const { service, gateway, storage } = createService({}, {
+        load: jest.fn().mockReturnValue(storedSession)
+      });
+
+      const listener = jest.fn();
+      service.subscribe(listener);
+      listener.mockClear();
+
+      await service.logout();
+
+      expect(gateway.logout).toHaveBeenCalledWith('persisted-token');
+      expect(storage.clear).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenLastCalledWith(null);
+      expect(service.getSession()).toBeNull();
+      expect(service.isAuthenticated()).toBe(false);
+    });
+
+    it('passes a null token to gateway logout when no session exists', async () => {
+      const { service, gateway } = createService();
+
+      await service.logout();
+
+      expect(gateway.logout).toHaveBeenCalledWith(null);
+    });
   });
 
-  it('clears the stored session when verification throws', async () => {
-    const storedSession = buildSession({ token: 'stale-token' });
-    const error = new Error('network-failure');
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  describe('restore', () => {
+    it('clears the stored session when verification returns null', async () => {
+      const storedSession = buildSession();
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
-    const { service, gateway, storage } = createService({
-      verifySession: jest.fn().mockRejectedValue(error)
-    }, {
-      load: jest.fn().mockReturnValue(storedSession)
+      const { service, gateway, storage } = createService({
+        verifySession: jest.fn().mockResolvedValue(null)
+      }, {
+        load: jest.fn().mockReturnValue(storedSession)
+      });
+
+      const listener = jest.fn();
+      service.subscribe(listener);
+
+      expect(service.getSession()).toEqual(storedSession);
+
+      const restored = await service.restore();
+
+      expect(restored).toBeNull();
+      expect(gateway.verifySession).toHaveBeenCalledWith(storedSession.token);
+      expect(storage.clear).toHaveBeenCalledTimes(1);
+      expect(service.getSession()).toBeNull();
+      expect(listener).toHaveBeenLastCalledWith(null);
+      expect(warnSpy).not.toHaveBeenCalled();
     });
 
-    const listener = jest.fn();
-    service.subscribe(listener);
+    it('clears the stored session when verification throws', async () => {
+      const storedSession = buildSession({ token: 'stale-token' });
+      const error = new Error('network-failure');
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
-    expect(service.getSession()).toEqual(storedSession);
+      const { service, gateway, storage } = createService({
+        verifySession: jest.fn().mockRejectedValue(error)
+      }, {
+        load: jest.fn().mockReturnValue(storedSession)
+      });
 
-    const restored = await service.restore();
+      const listener = jest.fn();
+      service.subscribe(listener);
 
-    expect(restored).toBeNull();
-    expect(gateway.verifySession).toHaveBeenCalledWith(storedSession.token);
-    expect(storage.clear).toHaveBeenCalledTimes(1);
-    expect(service.getSession()).toBeNull();
-    expect(listener).toHaveBeenLastCalledWith(null);
-    expect(warnSpy).toHaveBeenCalledWith('Failed to verify stored session', error);
+      expect(service.getSession()).toEqual(storedSession);
+
+      const restored = await service.restore();
+
+      expect(restored).toBeNull();
+      expect(gateway.verifySession).toHaveBeenCalledWith(storedSession.token);
+      expect(storage.clear).toHaveBeenCalledTimes(1);
+      expect(service.getSession()).toBeNull();
+      expect(listener).toHaveBeenLastCalledWith(null);
+      expect(warnSpy).toHaveBeenCalledWith('Failed to verify stored session', error);
+    });
   });
 });

--- a/shared/libs/auth/tests/auth-storage.test.ts
+++ b/shared/libs/auth/tests/auth-storage.test.ts
@@ -1,0 +1,79 @@
+import { LocalStorageAuthStorage } from '../src/auth-storage';
+import { AuthSession } from '../src/types';
+
+describe('LocalStorageAuthStorage', () => {
+  const session: AuthSession = {
+    token: 'token-123',
+    issuedAt: '2024-03-01T00:00:00.000Z',
+    user: {
+      id: 'user-1',
+      email: 'user@example.com',
+      name: 'User One',
+      role: 'administrator'
+    }
+  };
+
+  const originalDescriptor = Object.getOwnPropertyDescriptor(window, 'localStorage');
+
+  afterEach(() => {
+    if (originalDescriptor) {
+      Object.defineProperty(window, 'localStorage', originalDescriptor);
+    } else {
+      delete (window as unknown as Record<string, unknown>).localStorage;
+    }
+  });
+
+  it('loads and saves sessions via window.localStorage when available', () => {
+    const getItem = jest.fn().mockReturnValue(JSON.stringify(session));
+    const setItem = jest.fn();
+    const removeItem = jest.fn();
+
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: { getItem, setItem, removeItem }
+    });
+
+    const storage = new LocalStorageAuthStorage('test.session');
+
+    expect(storage.load()).toEqual(session);
+
+    storage.save(session);
+
+    expect(setItem).toHaveBeenCalledWith('test.session', JSON.stringify(session));
+
+    storage.clear();
+
+    expect(removeItem).toHaveBeenCalledWith('test.session');
+  });
+
+  it('removes malformed data from window.localStorage during load', () => {
+    const getItem = jest.fn().mockReturnValue('not-json');
+    const removeItem = jest.fn();
+
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: { getItem, setItem: jest.fn(), removeItem }
+    });
+
+    const storage = new LocalStorageAuthStorage('test.session');
+
+    expect(storage.load()).toBeNull();
+    expect(removeItem).toHaveBeenCalledWith('test.session');
+  });
+
+  it('falls back to in-memory storage when localStorage is unavailable', () => {
+    delete (window as unknown as Record<string, unknown>).localStorage;
+
+    const storage = new LocalStorageAuthStorage('test.session');
+
+    expect(storage.load()).toBeNull();
+
+    storage.save(session);
+
+    expect(storage.load()).toEqual(session);
+
+    storage.clear();
+
+    expect(storage.load()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- expand AuthService unit tests to exercise login/logout flows and subscription handling
- cover LocalStorageAuthStorage behavior for browser, error, and fallback scenarios

## Testing
- npm test -- --coverage

------
https://chatgpt.com/codex/tasks/task_e_68e006aad924832794fa493f993efc8c