### PR TITLE
Fix admin app TypeScript path resolution

### DIFF
--- a/services/admin-app/app/tsconfig.json
+++ b/services/admin-app/app/tsconfig.json
@@ -2,11 +2,7 @@
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": ".",
-    "outDir": "dist",
-    "paths": {
-      "@/*": ["src/*"]
-    }
+    "outDir": "dist"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- remove the admin app tsconfig baseUrl override so shared library path aliases resolve during builds

## Testing
- npm test -- --runInBand
- npm run build --prefix services/admin-app/app

------
https://chatgpt.com/codex/tasks/task_e_68e026050dc883278f2500888e55b266