### PR TITLE
Update ScyllaDB image to 2025.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   scylla:
-    image: scylladb/scylla:5.4
+    image: scylladb/scylla:2025.3
     container_name: tessaro-scylla
     command: ["--smp", "1", "--memory", "750M"]
     ports:
@@ -16,7 +16,7 @@ services:
       - scylla-data:/var/lib/scylla
 
   scylla-init:
-    image: scylladb/scylla:5.4
+    image: scylladb/scylla:2025.3
     container_name: tessaro-scylla-init
     depends_on:
       - scylla


### PR DESCRIPTION
## Summary
- update the ScyllaDB service images in docker-compose to use scylladb/scylla:2025.3

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e02620ba348327bba8f26dc4acd63a