### PR TITLE
Fix admin app entrypoint permissions

### DIFF
--- a/services/admin-app/app/Dockerfile
+++ b/services/admin-app/app/Dockerfile
@@ -27,7 +27,7 @@ COPY --from=builder /workspace/services/admin-app/app/dist ./dist
 COPY --from=builder /workspace/services/admin-app/app/vite.config.ts ./vite.config.ts
 COPY --from=builder /workspace/services/admin-app/app/tsconfig.json ./tsconfig.json
 COPY --from=builder /workspace/tsconfig.json /workspace/tsconfig.json
-COPY services/admin-app/app/docker-entrypoint.sh ./docker-entrypoint.sh
+COPY --from=builder /workspace/services/admin-app/app/docker-entrypoint.sh ./docker-entrypoint.sh
 ENTRYPOINT ["./docker-entrypoint.sh"]
 EXPOSE 4173
 ENV PORT=4173


### PR DESCRIPTION
## Summary
- copy the admin app entrypoint from the builder stage so its executable permissions are retained

## Testing
- not run (container image build requires docker)


------
https://chatgpt.com/codex/tasks/task_e_68e02ca022588327b5b31c5dea2913be