### PR TITLE
Allow unrestricted CORS in development mode

### DIFF
--- a/shared/config/app.ts
+++ b/shared/config/app.ts
@@ -3,6 +3,11 @@ import cors, { CorsOptions } from 'cors';
 
 export const resolveCorsOptions = (): CorsOptions => {
   const allowedOrigins = process.env.CORS_ALLOWED_ORIGINS;
+  const nodeEnv = process.env.NODE_ENV;
+
+  if (nodeEnv === 'development') {
+    return { origin: true };
+  }
 
   if (allowedOrigins === undefined) {
     return { origin: true };

--- a/shared/config/tests/app.test.ts
+++ b/shared/config/tests/app.test.ts
@@ -2,6 +2,7 @@ import { createBaseApp, resolveCorsOptions, resolveHost, resolvePort } from '../
 
 describe('resolveCorsOptions', () => {
   const originalEnv = process.env.CORS_ALLOWED_ORIGINS;
+  const originalNodeEnv = process.env.NODE_ENV;
 
   afterEach(() => {
     if (originalEnv === undefined) {
@@ -9,10 +10,23 @@ describe('resolveCorsOptions', () => {
     } else {
       process.env.CORS_ALLOWED_ORIGINS = originalEnv;
     }
+
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
   });
 
   it('allows all origins when the env var is missing', () => {
     delete process.env.CORS_ALLOWED_ORIGINS;
+
+    expect(resolveCorsOptions()).toEqual({ origin: true });
+  });
+
+  it('allows all origins when running in development', () => {
+    process.env.NODE_ENV = 'development';
+    process.env.CORS_ALLOWED_ORIGINS = 'https://example.com';
 
     expect(resolveCorsOptions()).toEqual({ origin: true });
   });


### PR DESCRIPTION
## Summary
- allow the shared Express app to permit all origins when NODE_ENV is development
- update the configuration tests to cover the new development behaviour and restore NODE_ENV after each case

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e02f30a5ec83279208d8822335f001