### PR TITLE
Fix admin app API URL for browser access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
     depends_on:
       - users-api
     environment:
-      VITE_USERS_API_URL: http://users-api:8080
+      VITE_USERS_API_URL: http://localhost:8080
     ports:
       - "4173:4173"
 


### PR DESCRIPTION
## Summary
- point the admin app's Users API URL to localhost so browsers can reach the service

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0317ba4688327ad548a10c8b7b0ec