### PR TITLE
Allow all origins for users API

### DIFF
--- a/shared/config/app.ts
+++ b/shared/config/app.ts
@@ -1,33 +1,7 @@
 import express, { Express } from 'express';
 import cors, { CorsOptions } from 'cors';
 
-export const resolveCorsOptions = (): CorsOptions => {
-  const allowedOrigins = process.env.CORS_ALLOWED_ORIGINS;
-  const nodeEnv = process.env.NODE_ENV;
-
-  if (nodeEnv === 'development') {
-    return { origin: true };
-  }
-
-  if (allowedOrigins === undefined) {
-    return { origin: true };
-  }
-
-  const parsedOrigins = allowedOrigins
-    .split(',')
-    .map((origin) => origin.trim())
-    .filter((origin) => origin.length > 0);
-
-  if (parsedOrigins.length === 0) {
-    return { origin: true };
-  }
-
-  if (parsedOrigins.length === 1) {
-    return { origin: parsedOrigins[0] };
-  }
-
-  return { origin: parsedOrigins };
-};
+export const resolveCorsOptions = (): CorsOptions => ({ origin: '*' });
 
 export const createBaseApp = (): Express => {
   const app = express();


### PR DESCRIPTION
## Summary
- simplify CORS configuration to always allow requests from any origin

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e033f86f8883278ba9e6f6034cbeb7