### PR TITLE
Update resolveCorsOptions tests to expect wildcard origin

### DIFF
--- a/shared/config/tests/app.test.ts
+++ b/shared/config/tests/app.test.ts
@@ -21,28 +21,26 @@ describe('resolveCorsOptions', () => {
   it('allows all origins when the env var is missing', () => {
     delete process.env.CORS_ALLOWED_ORIGINS;
 
-    expect(resolveCorsOptions()).toEqual({ origin: true });
+    expect(resolveCorsOptions()).toEqual({ origin: '*' });
   });
 
   it('allows all origins when running in development', () => {
     process.env.NODE_ENV = 'development';
     process.env.CORS_ALLOWED_ORIGINS = 'https://example.com';
 
-    expect(resolveCorsOptions()).toEqual({ origin: true });
+    expect(resolveCorsOptions()).toEqual({ origin: '*' });
   });
 
-  it('returns a single origin when only one value is provided', () => {
+  it('allows all origins when only one value is provided', () => {
     process.env.CORS_ALLOWED_ORIGINS = 'https://example.com';
 
-    expect(resolveCorsOptions()).toEqual({ origin: 'https://example.com' });
+    expect(resolveCorsOptions()).toEqual({ origin: '*' });
   });
 
-  it('returns a list of origins when multiple values are provided', () => {
+  it('allows all origins when multiple values are provided', () => {
     process.env.CORS_ALLOWED_ORIGINS = 'https://a.com, https://b.com ,  https://c.com ';
 
-    expect(resolveCorsOptions()).toEqual({
-      origin: ['https://a.com', 'https://b.com', 'https://c.com']
-    });
+    expect(resolveCorsOptions()).toEqual({ origin: '*' });
   });
 });
 


### PR DESCRIPTION
## Summary
- update resolveCorsOptions unit tests to expect the wildcard origin value

## Testing
- npm test -- shared/config/tests/app.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e0352a8ee48327aaa4d5d2aa3531ed