### PR TITLE
Reduce Scylla logging noise

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,12 @@ services:
   scylla:
     image: scylladb/scylla:2025.3
     container_name: tessaro-scylla
-    command: ["--smp", "1", "--memory", "750M"]
+    command: [
+      "--smp", "1",
+      "--memory", "750M",
+      "--logger-log-level", "scylla=warn",
+      "--logger-log-level", "seastar=warn"
+    ]
     ports:
       - "9042:9042"
     healthcheck:


### PR DESCRIPTION
## Summary
- configure the ScyllaDB container to emit only warning-level and above logs by default

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e037c3efac8327b7a709705233f97e