### PR TITLE
Simplify CORS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ The default configuration works out of the box. If you need to adjust connection
 
 * `SCYLLA_CONTACT_POINTS` — override the database host list for the APIs.
 * `SCYLLA_KEYSPACE` — change the keyspace name; remember to update [`infra/docker/scylla-init.cql`](./infra/docker/scylla-init.cql) accordingly.
-* `CORS_ALLOWED_ORIGINS` — restrict API access to specific origins.
 * `VITE_USERS_API_URL` — change the admin app's API base URL.
+
+APIs are configured to allow requests from any origin by default.
 
 ### Running Tests Locally
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,6 @@ services:
       SCYLLA_CONTACT_POINTS: scylla
       SCYLLA_LOCAL_DC: datacenter1
       SCYLLA_KEYSPACE: tessaro_admin
-      CORS_ALLOWED_ORIGINS: http://localhost:4173
     ports:
       - "8080:8080"
 

--- a/shared/config/tests/app.test.ts
+++ b/shared/config/tests/app.test.ts
@@ -1,45 +1,7 @@
 import { createBaseApp, resolveCorsOptions, resolveHost, resolvePort } from '../app';
 
 describe('resolveCorsOptions', () => {
-  const originalEnv = process.env.CORS_ALLOWED_ORIGINS;
-  const originalNodeEnv = process.env.NODE_ENV;
-
-  afterEach(() => {
-    if (originalEnv === undefined) {
-      delete process.env.CORS_ALLOWED_ORIGINS;
-    } else {
-      process.env.CORS_ALLOWED_ORIGINS = originalEnv;
-    }
-
-    if (originalNodeEnv === undefined) {
-      delete process.env.NODE_ENV;
-    } else {
-      process.env.NODE_ENV = originalNodeEnv;
-    }
-  });
-
-  it('allows all origins when the env var is missing', () => {
-    delete process.env.CORS_ALLOWED_ORIGINS;
-
-    expect(resolveCorsOptions()).toEqual({ origin: '*' });
-  });
-
-  it('allows all origins when running in development', () => {
-    process.env.NODE_ENV = 'development';
-    process.env.CORS_ALLOWED_ORIGINS = 'https://example.com';
-
-    expect(resolveCorsOptions()).toEqual({ origin: '*' });
-  });
-
-  it('allows all origins when only one value is provided', () => {
-    process.env.CORS_ALLOWED_ORIGINS = 'https://example.com';
-
-    expect(resolveCorsOptions()).toEqual({ origin: '*' });
-  });
-
-  it('allows all origins when multiple values are provided', () => {
-    process.env.CORS_ALLOWED_ORIGINS = 'https://a.com, https://b.com ,  https://c.com ';
-
+  it('always allows all origins', () => {
     expect(resolveCorsOptions()).toEqual({ origin: '*' });
   });
 });


### PR DESCRIPTION
## Summary
- remove environment-based CORS configuration references from documentation and docker compose
- simplify CORS unit test to reflect the always-open policy

## Testing
- CI=1 npx jest --runTestsByPath shared/config/tests/app.test.ts --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e03953d6108327b8b509992c91d692