### PR TITLE
Add docker-compose configuration for RavenDB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,4 @@
+services:
+  ravendb:
+    image: ravendb/ravendb:7.1-latest
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- add a docker compose file for RavenDB using the 7.1-latest image
- avoid exposing any RavenDB ports to the host

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e066d81e00832788f7e54a4f9ee362