### PR TITLE
Fix RavenDB volume permissions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,17 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ravendb-data:/opt/RavenDB/Server/RavenData
+      - ravendb-data:/var/lib/ravendb/data
+    depends_on:
+      ravendb-permissions:
+        condition: service_completed_successfully
+
+  ravendb-permissions:
+    image: busybox:1.36
+    command: ["sh", "-c", "chown -R 999:999 /var/lib/ravendb/data"]
+    volumes:
+      - ravendb-data:/var/lib/ravendb/data
+    restart: "no"
 
 volumes:
   ravendb-data:


### PR DESCRIPTION
## Summary
- mount the RavenDB data volume at the supported /var/lib/ravendb/data path
- add an init container that fixes the volume ownership before RavenDB starts

## Testing
- not run (docker is not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e06c36703483279f1c8daa76f5c286