### PR TITLE
Add admin app and users API to docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains the Tessaro admin experience along with supporting APIs
 | --- | --- | --- |
 | `admin-app` | Vite-powered React admin UI served in production preview mode. | `4173` |
 | `users-api` | Express API that provides CRUD operations for user profiles backed by RavenDB. | `8080` |
-| `ravendb` | RavenDB server used by the APIs. Studio is available on the exposed port. | `8080` |
+| `ravendb` | RavenDB server used by the APIs. Studio is available on the exposed port. | `8085` |
 
 Shared TypeScript packages live in the `shared/` directory and provide database clients, configuration helpers, and testing utilities that are consumed by the services.
 
@@ -33,7 +33,7 @@ No other local dependencies are required.
 3. Once the stack is ready:
    * Admin UI: http://localhost:4173
    * Users API: http://localhost:8080 (health check at `/health`)
-   * RavenDB Studio: http://localhost:8080
+   * RavenDB Studio: http://localhost:8085
 
 4. To stop the stack, press `Ctrl+C` and run:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,29 @@
 services:
+  admin-app:
+    build:
+      context: .
+      dockerfile: services/admin-app/app/Dockerfile
+    environment:
+      VITE_USERS_API_URL: http://users-api:8080
+    ports:
+      - "4173:4173"
+    depends_on:
+      - users-api
+
+  users-api:
+    build:
+      context: .
+      dockerfile: services/users-api/functions/Dockerfile
+    environment:
+      HOST: 0.0.0.0
+      PORT: 8080
+      RAVEN_URLS: http://ravendb:8080
+      RAVEN_DATABASE: Tessaro
+    ports:
+      - "8080:8080"
+    depends_on:
+      - ravendb
+
   ravendb:
     image: ravendb/ravendb:7.1-latest
     restart: unless-stopped
@@ -9,7 +34,7 @@ services:
       RAVEN_ServerUrl: http://0.0.0.0:8080
       RAVEN_PublicServerUrl: http://ravendb:8080
     ports:
-      - "8080:8080"
+      - "8085:8080"
     volumes:
       - ravendb-data:/var/lib/ravendb/data
     depends_on:


### PR DESCRIPTION
## Summary
- add admin-app and users-api services to docker-compose so the stack starts the UI and API alongside RavenDB
- expose RavenDB on a non-conflicting host port and wire the admin app to call the users API
- update the README to document the new RavenDB Studio port

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e06ed90c4c8327916386bc684e1d66