### PR TITLE
Add request logging to users API routes

### DIFF
--- a/services/users-api/functions/src/logger.ts
+++ b/services/users-api/functions/src/logger.ts
@@ -1,0 +1,44 @@
+import { Request } from 'express';
+
+type LogLevel = 'info' | 'warn' | 'error';
+
+const resolveConsoleMethod = (level: LogLevel): 'info' | 'warn' | 'error' => {
+  switch (level) {
+    case 'warn':
+      return 'warn';
+    case 'error':
+      return 'error';
+    case 'info':
+    default:
+      return 'info';
+  }
+};
+
+export const logRequest = (
+  req: Request<any, any, any, any, any>,
+  level: LogLevel = 'info'
+): void => {
+  const { method, originalUrl, ip, params, query, headers } = req;
+  const metadata: Record<string, unknown> = {
+    level,
+    method,
+    path: originalUrl,
+    ip,
+    params,
+    query,
+  };
+
+  if (req.body && Object.keys(req.body).length > 0) {
+    metadata.body = req.body;
+  }
+
+  const consoleMethod = resolveConsoleMethod(level);
+
+  // eslint-disable-next-line no-console
+  console[consoleMethod]('[UsersAPI] Incoming request', metadata, {
+    headers: {
+      'user-agent': headers['user-agent'],
+      'content-type': headers['content-type'],
+    },
+  });
+};

--- a/services/users-api/functions/src/routes.ts
+++ b/services/users-api/functions/src/routes.ts
@@ -2,11 +2,13 @@ import { Request, Response } from 'express';
 import { Express } from 'express-serve-static-core';
 import UserService from 'shared/libs/database/user-service';
 import { UserProfile } from 'shared/libs/database/types';
+import { logRequest } from './logger';
 
 export type CreateUserPayload = Omit<UserProfile, 'id' | 'created_at' | 'updated_at'>;
 
 export const registerListUsersRoute = (app: Express, userService: UserService): void => {
-  app.get('/users', async (_req: Request, res: Response) => {
+  app.get('/users', async (req: Request, res: Response) => {
+    logRequest(req);
     try {
       const users = await userService.listUsers();
       res.json(users);
@@ -18,6 +20,7 @@ export const registerListUsersRoute = (app: Express, userService: UserService): 
 
 export const registerCreateUserRoute = (app: Express, userService: UserService): void => {
   app.post('/users', async (req: Request<unknown, unknown, CreateUserPayload>, res: Response) => {
+    logRequest(req);
     try {
       const user = await userService.createUser(req.body);
       res.status(201).json(user);


### PR DESCRIPTION
## Summary
- add a reusable request logger for the users API functions
- log incoming request details when listing and creating users

## Testing
- npm test *(fails: missing `ravendb` module available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e071c67ebc83278f0dd6c02f471c63