### PR TITLE
chore: update admin app to node 22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@types/express": "^4.17.21",
         "@types/jest": "^29.5.12",
         "@types/mime-types": "^3.0.1",
-        "@types/node": "^20.11.30",
+        "@types/node": "^22.0.0",
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
         "@types/uuid": "^10.0.0",
@@ -1337,9 +1337,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",
-      "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
+      "version": "22.18.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.8.tgz",
+      "integrity": "sha512-pAZSHMiagDR7cARo/cch1f3rXy0AEXwsVsVH09FcyeJVAzCnGgmYis7P3JidtTUjyadhTeSo8TgRPswstghDaw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/express": "^4.17.21",
     "@types/jest": "^29.5.12",
     "@types/mime-types": "^3.0.1",
-    "@types/node": "^20.11.30",
+    "@types/node": "^22.0.0",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
     "@types/uuid": "^10.0.0",

--- a/services/admin-app/app/Dockerfile
+++ b/services/admin-app/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS base
+FROM node:22-alpine AS base
 WORKDIR /workspace
 
 FROM base AS deps
@@ -17,7 +17,7 @@ COPY . .
 RUN CI=true npm test -- --runInBand
 RUN npm run admin:build
 
-FROM node:20-alpine AS runner
+FROM node:22-alpine AS runner
 WORKDIR /workspace/services/admin-app/app
 ENV NODE_ENV=production
 COPY --from=builder /workspace/services/admin-app/app/package.json ./package.json

--- a/services/admin-app/app/package-lock.json
+++ b/services/admin-app/app/package-lock.json
@@ -15,7 +15,7 @@
         "uuid": "^9.0.1"
       },
       "devDependencies": {
-        "@types/node": "^20.11.30",
+        "@types/node": "^22.0.0",
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
         "@types/uuid": "^10.0.0",
@@ -56,7 +56,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1457,12 +1456,11 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",
-      "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
+      "version": "22.18.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.8.tgz",
+      "integrity": "sha512-pAZSHMiagDR7cARo/cch1f3rXy0AEXwsVsVH09FcyeJVAzCnGgmYis7P3JidtTUjyadhTeSo8TgRPswstghDaw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1480,7 +1478,6 @@
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1568,7 +1565,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -1969,7 +1965,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -1982,7 +1977,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2095,7 +2089,6 @@
       "integrity": "sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -2225,7 +2218,6 @@
       "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/services/admin-app/app/package.json
+++ b/services/admin-app/app/package.json
@@ -17,7 +17,7 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "@types/node": "^20.11.30",
+    "@types/node": "^22.0.0",
     "@types/uuid": "^10.0.0",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",


### PR DESCRIPTION
## Summary
- update the admin app Dockerfile to build and run on Node 22
- bump @types/node to a Node 22 compatible range and refresh both lockfiles

## Testing
- npm test -- --runInBand
- npm run admin:build
- docker compose build admin-app *(fails: docker command is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e07210cf508327a702a6fdb25ac85d