### PR TITLE
Handle graceful shutdown for users API

### DIFF
--- a/services/users-api/functions/src/server.ts
+++ b/services/users-api/functions/src/server.ts
@@ -11,10 +11,37 @@ const port = resolvePort(process.env.PORT);
 const host = resolveHost(process.env.HOST);
 
 if (require.main === module) {
-  app.listen(port, host, () => {
+  const server = app.listen(port, host, () => {
     // eslint-disable-next-line no-console
     console.log(`Users API listening on http://${host}:${port}`);
   });
+
+  let isShuttingDown = false;
+  const gracefulShutdown = (signal: NodeJS.Signals) => {
+    if (isShuttingDown) {
+      return;
+    }
+
+    isShuttingDown = true;
+    // eslint-disable-next-line no-console
+    console.log(`Received ${signal}. Users API shutting down gracefully.`);
+
+    server.close((error) => {
+      if (error) {
+        // eslint-disable-next-line no-console
+        console.error('Error while shutting down Users API server', error);
+        process.exit(1);
+        return;
+      }
+
+      // eslint-disable-next-line no-console
+      console.log('Users API shutdown complete.');
+      process.exit(0);
+    });
+  };
+
+  process.on('SIGINT', gracefulShutdown);
+  process.on('SIGTERM', gracefulShutdown);
 }
 
 export default app;


### PR DESCRIPTION
## Summary
- add graceful shutdown handling to the Users API server so it stops cleanly
- log shutdown progress and ensure the process exits with a success code when appropriate

## Testing
- npm test -- --runInBand --runTestsByPath services/users-api/functions/tests/user-service.test.ts *(hangs locally)*

------
https://chatgpt.com/codex/tasks/task_e_68e07332461c8327bf5f4d4c3ba208fc