### PR TITLE
Expose users API port

### DIFF
--- a/services/users-api/functions/Dockerfile
+++ b/services/users-api/functions/Dockerfile
@@ -10,5 +10,6 @@ COPY . .
 ENV NODE_ENV=production
 ENV PORT=8080
 ENV FUNCTION_ENTRY=services/users-api/functions/src/server.ts
+EXPOSE 8080
 
 CMD ["sh", "-c", "node -r ts-node/register/transpile-only -r tsconfig-paths/register ${FUNCTION_ENTRY}"]


### PR DESCRIPTION
## Summary
- expose port 8080 from the users-api container so it is reachable from the host

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0797db3a883278ef0d98912bd62bc