### PR TITLE
Fetch users from RavenDB

### DIFF
--- a/services/api-server/users.ts
+++ b/services/api-server/users.ts
@@ -1,9 +1,58 @@
 // users.ts
 import { Hono } from 'hono'
+import { DocumentStore } from 'npm:ravendb'
 
 const app = new Hono()
 
-app.get('/', (c) => c.json('list users'))
+const ravenUrls = Deno.env.get('RAVEN_URLS')
+  ?.split(',')
+  .map((url) => url.trim())
+  .filter(Boolean) ?? []
+const ravenDatabase = Deno.env.get('RAVEN_DATABASE') ?? ''
+
+let documentStore: DocumentStore | null = null
+
+function getDocumentStore() {
+  if (documentStore || ravenUrls.length === 0 || !ravenDatabase) {
+    return documentStore
+  }
+
+  try {
+    documentStore = new DocumentStore(ravenUrls, ravenDatabase)
+    documentStore.initialize()
+  } catch (error) {
+    console.error('Failed to initialize RavenDB document store', error)
+    documentStore = null
+  }
+
+  return documentStore
+}
+
+app.get('/', async (c) => {
+  const store = getDocumentStore()
+
+  if (!store) {
+    return c.json([])
+  }
+
+  const session = store.openSession()
+
+  try {
+    const users = await session
+      .query({ collection: 'Users' })
+      .all()
+
+    return c.json(users ?? [])
+  } catch (error) {
+    console.error('Failed to load users from RavenDB', error)
+    return c.json([])
+  } finally {
+    if (typeof session.dispose === 'function') {
+      session.dispose()
+    }
+  }
+})
+
 app.post('/', (c) => c.json('create a user', 201))
 app.get('/:id', (c) => c.json(`get ${c.req.param('id')}`))
 


### PR DESCRIPTION
## Summary
- create a RavenDB document store and query the Users collection for the users endpoint
- handle initialization and query errors by returning an empty list when data is unavailable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0926df7d083279042ed8e426678ef