### PR TITLE
Add api-server service to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,23 @@ services:
       context: .
       dockerfile: services/admin-app/app/Dockerfile
     environment:
-      VITE_USERS_API_URL: http://users-api:8080
+      VITE_USERS_API_URL: http://api-server:8080
     ports:
       - "4173:4173"
     depends_on:
-      - users-api
+      - api-server
+
+  api-server:
+    build:
+      context: .
+      dockerfile: services/api-server/Dockerfile
+    environment:
+      RAVEN_URLS: http://ravendb:8080
+      RAVEN_DATABASE: Users
+    ports:
+      - "8080:8000"
+    depends_on:
+      - ravendb
 
   ravendb:
     image: ravendb/ravendb:7.1-latest


### PR DESCRIPTION
## Summary
- add the api-server service definition to docker-compose
- expose the API on port 8080 and configure RavenDB connection settings
- point the admin app to the new api-server container

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0945d9130832786491a8707cd6444