### PR TITLE
Fix Deno lint violations in API server

### DIFF
--- a/services/api-server/deno.json
+++ b/services/api-server/deno.json
@@ -2,5 +2,8 @@
   "tasks": {
     "start": "deno run --allow-net --allow-env main.ts",
     "test": "deno test --allow-env --unsafely-ignore-certificate-errors=deno.land,jsr.io,registry.npmjs.org"
+  },
+  "imports": {
+    "ravendb": "npm:ravendb@7.1.0"
   }
 }

--- a/services/api-server/deno.lock
+++ b/services/api-server/deno.lock
@@ -1,7 +1,8 @@
 {
   "version": "5",
   "specifiers": {
-    "npm:ravendb@*": "7.1.0"
+    "npm:ravendb@*": "7.1.0",
+    "npm:ravendb@7.1.0": "7.1.0"
   },
   "npm": {
     "@rollup/rollup-linux-x64-gnu@4.52.4": {
@@ -59,5 +60,10 @@
     "ws@8.18.3": {
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="
     }
+  },
+  "workspace": {
+    "dependencies": [
+      "npm:ravendb@7.1.0"
+    ]
   }
 }

--- a/services/api-server/users.ts
+++ b/services/api-server/users.ts
@@ -70,7 +70,7 @@ async function getDocumentStore() {
   if (!documentStoreInitPromise) {
     documentStoreInitPromise = (async () => {
       try {
-        const module = await import("npm:ravendb");
+        const module = await import("ravendb");
         const Store = module.DocumentStore as unknown as new (
           urls: string[],
           database: string,
@@ -90,7 +90,7 @@ async function getDocumentStore() {
     })();
   }
 
-  return documentStoreInitPromise;
+  return await documentStoreInitPromise;
 }
 
 app.get("/", async (c: Context) => {


### PR DESCRIPTION
## Summary
- register the ravendb dependency in the API server Deno config so linting accepts the dynamic import
- ensure the RavenDB document store helper awaits its initialization promise to satisfy lint

## Testing
- DENO_TLS_CA_STORE=system deno task test
- deno lint

------
https://chatgpt.com/codex/tasks/task_e_68e0a4f1947883279066cf3586201795