### PR TITLE
Add helper script to run admin TUI with dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,13 @@ Each API has an accompanying Dockerfile and can be extended with additional rout
 * Update shared libraries under `shared/` to expose cross-service utilities.
 
 Feel free to tailor the Compose file to match your deployment or development needs.
+
+### Running the Admin TUI in isolation
+
+When you only need the terminal UI, use the helper script to ensure the API server and RavenDB are started before launching the container:
+
+```bash
+./scripts/run_admin_tui.sh
+```
+
+Any services started by the script are stopped automatically once you exit the TUI.

--- a/scripts/run_admin_tui.sh
+++ b/scripts/run_admin_tui.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${PROJECT_ROOT}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Error: docker is required to run this script." >&2
+  exit 1
+fi
+
+if ! docker compose version >/dev/null 2>&1; then
+  echo "Error: docker compose is required to run this script." >&2
+  exit 1
+fi
+
+started_services=()
+start_service_if_needed() {
+  local service="$1"
+  if [[ -z "$(docker compose ps -q "${service}")" ]]; then
+    echo "Starting ${service}..."
+    docker compose up -d "${service}"
+    started_services+=("${service}")
+  else
+    echo "${service} is already running."
+  fi
+}
+
+cleanup() {
+  if [[ ${#started_services[@]} -gt 0 ]]; then
+    echo "\nStopping services started by this script..."
+    docker compose stop "${started_services[@]}"
+  fi
+}
+trap cleanup EXIT
+
+start_service_if_needed ravendb
+start_service_if_needed api-server
+
+cat <<'MSG'
+\nAdmin TUI is starting. Use Ctrl+C to exit.\nMSG
+
+docker compose run --rm admin-tui


### PR DESCRIPTION
## Summary
- add a helper script that ensures RavenDB and the API server are running before launching the admin TUI container
- document the new script in the README so the TUI can be started in isolation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2ec7b25d88327a98269d59d90b25c