### PR TITLE
Fix admin TUI startup message

### DIFF
--- a/scripts/run_admin_tui.sh
+++ b/scripts/run_admin_tui.sh
@@ -38,7 +38,6 @@ trap cleanup EXIT
 start_service_if_needed ravendb
 start_service_if_needed api-server
 
-cat <<'MSG'
-\nAdmin TUI is starting. Use Ctrl+C to exit.\nMSG
+printf '\nAdmin TUI is starting. Use Ctrl+C to exit.\n\n'
 
 docker compose run --rm admin-tui


### PR DESCRIPTION
## Summary
- print the admin TUI startup banner with printf so the message renders correctly and the launch command executes

## Testing
- bash -n scripts/run_admin_tui.sh

------
https://chatgpt.com/codex/tasks/task_e_68e2ed84c2f483279967e162336a2666